### PR TITLE
feat(op): switch edge index to LibTorch Stable ABI

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -43,10 +43,6 @@ jobs:
           - os: ubuntu-24.04-arm
             python: 312
             platform_id: manylinux_aarch64
-          # macos-x86-64
-          - os: macos-15-intel
-            python: 312
-            platform_id: macosx_x86_64
           # macos-arm64
           - os: macos-14
             python: 312

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -45,27 +45,14 @@ if(BUILD_CPP_IF
   list(APPEND CMAKE_PREFIX_PATH ${PYTORCH_CMAKE_PREFIX_PATH})
 endif()
 find_package(Torch REQUIRED)
+if(Torch_VERSION VERSION_LESS "2.10.0")
+  message(FATAL_ERROR "deepmd-gnn OP requires PyTorch >= 2.10.0 for the "
+                      "LibTorch Stable ABI.")
+endif()
 if(NOT Torch_VERSION VERSION_LESS "2.1.0")
   set_if_higher(CMAKE_CXX_STANDARD 17)
 elseif(NOT Torch_VERSION VERSION_LESS "1.5.0")
   set_if_higher(CMAKE_CXX_STANDARD 14)
-endif()
-string(REGEX MATCH "_GLIBCXX_USE_CXX11_ABI=([0-9]+)" CXXABI_PT_MATCH
-             "${TORCH_CXX_FLAGS}")
-if(CXXABI_PT_MATCH)
-  set(OP_CXX_ABI_PT ${CMAKE_MATCH_1})
-  message(STATUS "PyTorch CXX11 ABI: ${CMAKE_MATCH_1}")
-else()
-  # Maybe in macos/windows
-  if(UNIX
-     AND NOT APPLE
-     AND Torch_VERSION VERSION_GREATER_EQUAL "2.8.0")
-    # https://github.com/deepmodeling/deepmd-kit/issues/4877
-    # torch.compiled_with_cxx11_abi in PyTorch 2.8 always return True
-    set(OP_CXX_ABI_PT 1)
-  else()
-    set(OP_CXX_ABI_PT 0)
-  endif()
 endif()
 
 # define build type

--- a/build_backend/dp_backend.py
+++ b/build_backend/dp_backend.py
@@ -36,6 +36,7 @@ def cibuildwheel_dependencies() -> list[str]:
         or os.environ.get("READTHEDOCS", "0") == "True"
     ):
         return [
+            "torch>=2.10",
             "deepmd-kit[torch]>=3.0.0b2",
         ]
     return []

--- a/op/CMakeLists.txt
+++ b/op/CMakeLists.txt
@@ -3,9 +3,6 @@ file(GLOB OP_SRC edge_index.cc)
 add_library(deepmd_gnn MODULE ${OP_SRC})
 # link: libdeepmd libtorch
 target_link_libraries(deepmd_gnn PRIVATE ${TORCH_LIBRARIES})
-target_compile_definitions(
-  deepmd_gnn
-  PUBLIC "$<$<COMPILE_LANGUAGE:CXX>:_GLIBCXX_USE_CXX11_ABI=${OP_CXX_ABI_PT}>")
 if(APPLE)
   set_target_properties(deepmd_gnn PROPERTIES INSTALL_RPATH "@loader_path")
 else()

--- a/op/edge_index.cc
+++ b/op/edge_index.cc
@@ -98,11 +98,9 @@ ts::Tensor edge_index_kernel(const ts::Tensor& nlist_tensor,
   }
 
   const int64_t edge_size = static_cast<int64_t>(edge_index.size() / 2);
-  ts::Tensor edge_index_tensor = ts::empty(
-      {edge_size, 2},
-      th::ScalarType::Long,
-      th::Layout::Strided,
-      ts::Device(th::DeviceType::CPU));
+  ts::Tensor edge_index_tensor =
+      ts::empty({edge_size, 2}, th::ScalarType::Long, th::Layout::Strided,
+                ts::Device(th::DeviceType::CPU));
   int64_t* edge_index_data = edge_index_tensor.mutable_data_ptr<int64_t>();
   std::copy(edge_index.begin(), edge_index.end(), edge_index_data);
   return ts::to(edge_index_tensor, nlist_tensor.device());

--- a/op/edge_index.cc
+++ b/op/edge_index.cc
@@ -1,41 +1,65 @@
 // SPDX-License-Identifier: LGPL-3.0-or-later
-#include <torch/torch.h>
+// Target the oldest stable ABI version used by this file's helper APIs.
+#ifndef TORCH_TARGET_VERSION
+#define TORCH_TARGET_VERSION (((0ULL + 2) << 56) | ((0ULL + 10) << 48))
+#endif
 
-#include <iostream>
+#include <torch/csrc/stable/library.h>
+#include <torch/csrc/stable/ops.h>
+#include <torch/csrc/stable/tensor.h>
 
-torch::Tensor edge_index_kernel(const torch::Tensor& nlist_tensor,
-                                const torch::Tensor& atype_tensor,
-                                const torch::Tensor& mm_tensor) {
-  torch::Tensor nlist_tensor_ = nlist_tensor.cpu().contiguous();
-  torch::Tensor atype_tensor_ = atype_tensor.cpu().contiguous();
-  torch::Tensor mm_tensor_ = mm_tensor.cpu().contiguous();
+#include <algorithm>
+#include <cstdint>
+#include <stdexcept>
+#include <vector>
+
+namespace {
+namespace th = torch::headeronly;
+namespace ts = torch::stable;
+
+ts::Tensor to_cpu_contiguous(const ts::Tensor& tensor) {
+  return ts::contiguous(ts::to(tensor, ts::Device(th::DeviceType::CPU)));
+}
+
+ts::Tensor edge_index_kernel(const ts::Tensor& nlist_tensor,
+                             const ts::Tensor& atype_tensor,
+                             const ts::Tensor& mm_tensor) {
+  ts::Tensor nlist_tensor_ = to_cpu_contiguous(nlist_tensor);
+  ts::Tensor atype_tensor_ = to_cpu_contiguous(atype_tensor);
+  ts::Tensor mm_tensor_ = to_cpu_contiguous(mm_tensor);
+
+  int64_t nf = 0;
+  int64_t nloc = 0;
+  int64_t nnei = 0;
+  int64_t nall = 0;
   if (nlist_tensor_.dim() == 2) {
-    nlist_tensor_ =
-        nlist_tensor_.view({1, nlist_tensor_.size(0), nlist_tensor_.size(1)});
     if (atype_tensor_.dim() != 1) {
       throw std::invalid_argument("atype_tensor must be 1D");
     }
-    atype_tensor_ = atype_tensor_.view({1, atype_tensor_.size(0)});
+    nf = 1;
+    nloc = nlist_tensor_.size(0);
+    nnei = nlist_tensor_.size(1);
+    nall = atype_tensor_.size(0);
   } else if (nlist_tensor_.dim() == 3) {
     if (atype_tensor_.dim() != 2) {
       throw std::invalid_argument("atype_tensor must be 2D");
     }
+    nf = nlist_tensor_.size(0);
+    nloc = nlist_tensor_.size(1);
+    nnei = nlist_tensor_.size(2);
+    if (atype_tensor_.size(0) != nf) {
+      throw std::invalid_argument(
+          "atype_tensor must have the same size as nlist_tensor");
+    }
+    nall = atype_tensor_.size(1);
   } else {
     throw std::invalid_argument("nlist_tensor must be 2D or 3D");
   }
 
-  const int64_t nf = nlist_tensor_.size(0);
-  const int64_t nloc = nlist_tensor_.size(1);
-  const int64_t nnei = nlist_tensor_.size(2);
-  if (atype_tensor_.size(0) != nf) {
-    throw std::invalid_argument(
-        "atype_tensor must have the same size as nlist_tensor");
-  }
-  const int64_t nall = atype_tensor_.size(1);
   const int64_t nmm = mm_tensor_.size(0);
-  int64_t* nlist = nlist_tensor_.view({-1}).data_ptr<int64_t>();
-  int64_t* atype = atype_tensor_.view({-1}).data_ptr<int64_t>();
-  int64_t* mm = mm_tensor_.view({-1}).data_ptr<int64_t>();
+  const int64_t* nlist = nlist_tensor_.const_data_ptr<int64_t>();
+  const int64_t* atype = atype_tensor_.const_data_ptr<int64_t>();
+  const int64_t* mm = mm_tensor_.const_data_ptr<int64_t>();
 
   std::vector<int64_t> edge_index;
   edge_index.reserve(nf * nloc * nnei * 2);
@@ -43,14 +67,13 @@ torch::Tensor edge_index_kernel(const torch::Tensor& nlist_tensor,
   for (int64_t ff = 0; ff < nf; ff++) {
     for (int64_t ii = 0; ii < nloc; ii++) {
       for (int64_t jj = 0; jj < nnei; jj++) {
-        int64_t idx = ff * nloc * nnei + ii * nnei + jj;
-        int64_t kk = nlist[idx];
+        const int64_t idx = ff * nloc * nnei + ii * nnei + jj;
+        const int64_t kk = nlist[idx];
         if (kk < 0) {
           continue;
         }
-        int64_t global_kk = ff * nall + kk;
-        int64_t global_ii = ff * nall + ii;
-        // check if both atype[ii] and atype[kk] are in mm
+        const int64_t global_kk = ff * nall + kk;
+        const int64_t global_ii = ff * nall + ii;
         bool in_mm1 = false;
         for (int64_t mm_idx = 0; mm_idx < nmm; mm_idx++) {
           if (atype[global_ii] == mm[mm_idx]) {
@@ -68,20 +91,31 @@ torch::Tensor edge_index_kernel(const torch::Tensor& nlist_tensor,
         if (in_mm1 && in_mm2) {
           continue;
         }
-        // add edge
         edge_index.push_back(global_kk);
         edge_index.push_back(global_ii);
       }
     }
   }
-  // convert to tensor
-  int64_t edge_size = edge_index.size() / 2;
-  torch::Tensor edge_index_tensor =
-      torch::tensor(edge_index, torch::kInt64).view({edge_size, 2});
-  // to nlist_tensor.device
-  return edge_index_tensor.to(nlist_tensor.device());
+
+  const int64_t edge_size = static_cast<int64_t>(edge_index.size() / 2);
+  ts::Tensor edge_index_tensor = ts::empty(
+      {edge_size, 2},
+      th::ScalarType::Long,
+      th::Layout::Strided,
+      ts::Device(th::DeviceType::CPU));
+  int64_t* edge_index_data = edge_index_tensor.mutable_data_ptr<int64_t>();
+  std::copy(edge_index.begin(), edge_index.end(), edge_index_data);
+  return ts::to(edge_index_tensor, nlist_tensor.device());
+}
+}  // namespace
+
+STABLE_TORCH_LIBRARY(deepmd_gnn, m) {
+  m.def("edge_index(Tensor nlist, Tensor atype, Tensor mm) -> Tensor");
+  m.impl("edge_index", TORCH_BOX(edge_index_kernel));
 }
 
-TORCH_LIBRARY(deepmd_gnn, m) { m.def("edge_index", edge_index_kernel); }
-// compatbility with old models freezed by deepmd_mace package
-TORCH_LIBRARY(deepmd_mace, m) { m.def("mace_edge_index", edge_index_kernel); }
+// Compatibility with old models frozen by deepmd_mace package.
+STABLE_TORCH_LIBRARY(deepmd_mace, m) {
+  m.def("mace_edge_index(Tensor nlist, Tensor atype, Tensor mm) -> Tensor");
+  m.impl("mace_edge_index", TORCH_BOX(edge_index_kernel));
+}

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -24,7 +24,7 @@ classifiers = [
     "License :: OSI Approved :: GNU Lesser General Public License v3 (LGPLv3)",
 ]
 dependencies = [
-    "torch",
+    "torch>=2.10",
     "deepmd-kit[torch]>=3.0.0",
     "mace-torch>=0.3.5",
     "nequip",


### PR DESCRIPTION
## Summary
- migrate the `edge_index` custom op from the LibTorch C++ frontend to LibTorch Stable ABI registration
- remove the `_GLIBCXX_USE_CXX11_ABI` binding from the op target
- require PyTorch >= 2.10 for the stable ABI build path

## Validation
- `ruff check . && ruff format .`
- `cmake -S /home/jzzeng/codes/deepmd-gnn -B /tmp/deepmd-gnn-stable-build -DBUILD_PY_IF=ON -DBUILD_CPP_IF=OFF -DCMAKE_PREFIX_PATH=$(python -c "import torch;print(torch.utils.cmake_prefix_path)")`
- `cmake --build /tmp/deepmd-gnn-stable-build --target deepmd_gnn -j2`
- loaded `/tmp/deepmd-gnn-stable-build/op/libdeepmd_gnn.so` and checked `deepmd_gnn.edge_index` / `deepmd_mace.mace_edge_index` against existing one-frame and two-frame expected outputs

Note: validation used a temporary CPU-only PyTorch venv. `clang-format` is not installed in this environment.