### PR TITLE
fix: avoid linking torch cuda for CPU op

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -15,8 +15,8 @@ option(BUILD_PY_IF "Build Python interfaces" OFF)
 option(USE_PT_PYTHON_LIBS "Use PyTorch Python libraries" OFF)
 option(DEEPMD_GNN_BYPASS_TORCH_CUDA_CHECK
        "Bypass PyTorch CUDA toolkit discovery when nvcc is unavailable" ON)
-option(DEEPMD_GNN_LINK_TORCH_CUDA
-       "Link the OP against PyTorch CUDA libraries" OFF)
+option(DEEPMD_GNN_LINK_TORCH_CUDA "Link the OP against PyTorch CUDA libraries"
+       OFF)
 
 if((NOT BUILD_PY_IF) AND (NOT BUILD_CPP_IF))
   # nothing to do

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -15,6 +15,8 @@ option(BUILD_PY_IF "Build Python interfaces" OFF)
 option(USE_PT_PYTHON_LIBS "Use PyTorch Python libraries" OFF)
 option(DEEPMD_GNN_BYPASS_TORCH_CUDA_CHECK
        "Bypass PyTorch CUDA toolkit discovery when nvcc is unavailable" ON)
+option(DEEPMD_GNN_LINK_TORCH_CUDA
+       "Link the OP against PyTorch CUDA libraries" OFF)
 
 if((NOT BUILD_PY_IF) AND (NOT BUILD_CPP_IF))
   # nothing to do
@@ -62,6 +64,11 @@ find_package(Torch REQUIRED)
 if(Torch_VERSION VERSION_LESS "2.10.0")
   message(FATAL_ERROR "deepmd-gnn OP requires PyTorch >= 2.10.0 for the "
                       "LibTorch Stable ABI.")
+endif()
+set(DEEPMD_GNN_TORCH_LIBRARIES ${TORCH_LIBRARIES})
+if((NOT DEEPMD_GNN_LINK_TORCH_CUDA) AND TARGET torch_cpu)
+  set(DEEPMD_GNN_TORCH_LIBRARIES torch_cpu)
+  message(STATUS "Linking deepmd-gnn OP against PyTorch CPU runtime")
 endif()
 if(NOT Torch_VERSION VERSION_LESS "2.1.0")
   set_if_higher(CMAKE_CXX_STANDARD 17)

--- a/op/CMakeLists.txt
+++ b/op/CMakeLists.txt
@@ -1,8 +1,13 @@
 file(GLOB OP_SRC edge_index.cc)
 
 add_library(deepmd_gnn MODULE ${OP_SRC})
-# link: libdeepmd libtorch
-target_link_libraries(deepmd_gnn PRIVATE ${TORCH_LIBRARIES})
+target_include_directories(deepmd_gnn PRIVATE ${TORCH_INCLUDE_DIRS})
+if(TORCH_CXX_FLAGS)
+  separate_arguments(DEEPMD_GNN_TORCH_CXX_FLAGS NATIVE_COMMAND
+                     "${TORCH_CXX_FLAGS}")
+  target_compile_options(deepmd_gnn PRIVATE ${DEEPMD_GNN_TORCH_CXX_FLAGS})
+endif()
+target_link_libraries(deepmd_gnn PRIVATE ${DEEPMD_GNN_TORCH_LIBRARIES})
 if(APPLE)
   set_target_properties(deepmd_gnn PROPERTIES INSTALL_RPATH "@loader_path")
 else()


### PR DESCRIPTION
## Summary
- link the OP against PyTorch's CPU runtime target by default
- keep an opt-in CMake switch to link PyTorch CUDA libraries when needed
- pass Torch include dirs and compile flags explicitly instead of relying on the full Torch link target

## Tests
- git diff --check
- cmake configure/build with CUDA PyTorch; verified DT_NEEDED only includes libtorch_cpu.so and libc10.so
- cmake configure/build with -DDEEPMD_GNN_LINK_TORCH_CUDA=ON; verified original CUDA link behavior remains available
- pytest -q tests/test_op.py using a temporary install