### PR TITLE
feat: enable MACE MPI communication in LAMMPS

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,28 +91,28 @@ For details, follow [DeePMD-kit documentation](https://docs.deepmodeling.com/pro
 GNN models use message passing neural networks,
 so the neighbor list built with traditional cutoff radius will not work,
 since the ghost atoms also need to build neighbor list.
-By default, the model requests the neighbor list with a cutoff radius of $r_c \times N_{L}$,
-where $r_c$ is set by `r_max` and $N_L$ is set by `num_interactions` (MACE) / `num_layers` (NequIP),
+For NequIP, the model requests the neighbor list with a cutoff radius of $r_c \times N_{L}$,
+where $r_c$ is set by `r_max` and $N_L$ is set by `num_layers`,
 and rebuilds the neighbor list for ghost atoms.
 However, this approach is very inefficient.
 
-The alternative approach for the MACE model (note: NequIP doesn't support such approach) is to use the mapping passed from LAMMPS, which does not support MPI.
-One needs to set `DP_GNN_USE_MAPPING` when freezing the models,
+The MACE model works like a regular DeePMD-kit message-passing model.
+No extra environment variable is needed when freezing the model.
+It advertises message passing to DeePMD-kit, so LAMMPS can use the regular
+neighbor list with a cutoff radius of $r_c$ and DeePMD-kit communicates
+the ghost-atom features through MPI between message-passing layers.
+This requires a DeePMD-kit build whose LAMMPS/PyTorch interface provides
+the message-passing communication op, `border_op`.
 
-```sh
-DP_GNN_USE_MAPPING=1 dp --pt freeze
-```
-
-and request the mapping when using LAMMPS (also requires DeePMD-kit v3.0.0rc0 or above).
+The non-MPI mapping approach is still available for the MACE model
+(note: NequIP doesn't support such approach), but it does not support MPI.
+Request the mapping when using LAMMPS (also requires DeePMD-kit v3.0.0rc0 or above).
 By using the mapping, the ghost atoms will be mapped to the real atoms,
 so the regular neighbor list with a cutoff radius of $r_c$ can be used.
 
 ```lammps
 atom_modify map array
 ```
-
-In the future, we will explore utilizing the MPI to communicate the neighbor list,
-while this approach requires a deep hack for external packages.
 
 ## Parameters
 

--- a/deepmd_gnn/env.py
+++ b/deepmd_gnn/env.py
@@ -1,5 +1,5 @@
-"""Configurations read from environment variables."""
+"""Runtime configuration helpers.
 
-import os
-
-DP_GNN_USE_MAPPING = os.environ.get("DP_GNN_USE_MAPPING", "0") == "1"
+The MACE LAMMPS communication path is model-driven and does not require
+environment-variable switches.
+"""

--- a/deepmd_gnn/mace.py
+++ b/deepmd_gnn/mace.py
@@ -20,7 +20,6 @@ from deepmd.pt.model.model.transform_output import (
 )
 from deepmd.pt.utils import env
 from deepmd.pt.utils.nlist import (
-    build_neighbor_list,
     extend_input_and_build_neighbor_list,
 )
 from deepmd.pt.utils.stat import (
@@ -55,8 +54,29 @@ from mace.modules import (
 )
 
 import deepmd_gnn.op  # noqa: F401
-from deepmd_gnn import env as deepmd_gnn_env
 from deepmd_gnn.autograd import derive_atomic_virial_from_displacement
+
+if not hasattr(torch.ops.deepmd, "border_op"):  # pragma: no cover
+
+    def border_op(
+        _argument0: torch.Tensor,
+        _argument1: torch.Tensor,
+        _argument2: torch.Tensor,
+        _argument3: torch.Tensor,
+        _argument4: torch.Tensor,
+        _argument5: torch.Tensor,
+        _argument6: torch.Tensor,
+        _argument7: torch.Tensor,
+        _argument8: torch.Tensor,
+    ) -> list[torch.Tensor]:
+        """TorchScript placeholder used when DeePMD's PT op is not loaded."""
+        msg = (
+            "border_op is unavailable. Build/load DeePMD-kit's PyTorch OP "
+            "library before running MPI message-passing inference."
+        )
+        raise NotImplementedError(msg)
+
+    torch.ops.deepmd.border_op = border_op
 
 
 def _load_observed_type_stat_compat() -> tuple[Any, Any, Any]:
@@ -453,9 +473,7 @@ class MaceModel(BaseModel):
     @torch.jit.export
     def get_rcut(self) -> float:
         """Get the cut-off radius."""
-        if deepmd_gnn_env.DP_GNN_USE_MAPPING:
-            return self.rcut
-        return self.rcut * self.num_interactions
+        return self.rcut
 
     @torch.jit.export
     def get_type_map(self) -> list[str]:
@@ -511,6 +529,11 @@ class MaceModel(BaseModel):
     @torch.jit.export
     def has_message_passing(self) -> bool:
         """Return whether the descriptor has message passing."""
+        return self.num_interactions > 1
+
+    @torch.jit.export
+    def need_sorted_nlist_for_lower(self) -> bool:
+        """Return whether lower-interface neighbor lists must be sorted."""
         return False
 
     @torch.jit.export
@@ -617,25 +640,20 @@ class MaceModel(BaseModel):
             The communication dictionary.
         """
         nloc = nlist.shape[1]
-        nf, nall = extended_atype.shape
+        _nf, nall = extended_atype.shape
         # calculate nlist for ghost atoms, as LAMMPS does not calculate it
-        if mapping is None and self.num_interactions > 1 and nloc < nall:
-            if deepmd_gnn_env.DP_GNN_USE_MAPPING:
-                # when setting DP_GNN_USE_MAPPING, ghost atoms are only built
-                # for one message-passing layer
-                msg = (
-                    "When setting DP_GNN_USE_MAPPING, mapping is required. "
-                    "If you are using LAMMPS, set `atom_modify map yes`."
-                )
-                raise ValueError(msg)
-            nlist = build_neighbor_list(
-                extended_coord.view(nf, -1),
-                extended_atype,
-                nall,
-                self.rcut,
-                self.sel,
-                distinguish_types=False,
+        if (
+            mapping is None
+            and comm_dict is None
+            and self.num_interactions > 1
+            and nloc < nall
+        ):
+            msg = (
+                "Multi-layer MACE lower inference requires either comm_dict "
+                "from DeePMD-kit message-passing communication or a mapping "
+                "from extended atoms to local atoms."
             )
+            raise ValueError(msg)
 
         model_ret = self.forward_lower_common(
             nloc,
@@ -701,9 +719,6 @@ class MaceModel(BaseModel):
         if aparam is not None:
             msg = "aparam is unsupported"
             raise ValueError(msg)
-        if comm_dict is not None:
-            msg = "comm_dict is unsupported"
-            raise ValueError(msg)
         nlist = nlist.to(torch.int64)
         extended_atype = extended_atype.to(torch.int64)
         nall = extended_coord.shape[1]
@@ -735,7 +750,12 @@ class MaceModel(BaseModel):
             dtype=default_dtype,
             device=extended_coord_ff.device,
         )
-        if self.num_interactions > 1 and mapping is not None and nloc < nall:
+        if (
+            self.num_interactions > 1
+            and comm_dict is None
+            and mapping is not None
+            and nloc < nall
+        ):
             mapping_ff = mapping.view(nf * nall) + torch.arange(
                 0,
                 nf * nall,
@@ -824,21 +844,32 @@ class MaceModel(BaseModel):
             )
             input_dict["shifts"] = shifts
 
-        ret = self.model.forward(
-            input_dict,
-            compute_force=False,
-            compute_virials=False,
-            compute_stress=False,
-            compute_displacement=False,
-            training=self.training,
-        )
+        if comm_dict is None:
+            ret = self.model.forward(
+                input_dict,
+                compute_force=False,
+                compute_virials=False,
+                compute_stress=False,
+                compute_displacement=False,
+                training=self.training,
+            )
 
-        atom_energy_all = ret["node_energy"]
-        if atom_energy_all is None:
-            msg = "atom_energy is None"
-            raise ValueError(msg)
-        atom_energy_all = atom_energy_all.view(nf, nall)
-        atom_energy = atom_energy_all[:, :nloc]
+            atom_energy_all = ret["node_energy"]
+            if atom_energy_all is None:
+                msg = "atom_energy is None"
+                raise ValueError(msg)
+            atom_energy_all = atom_energy_all.view(nf, nall)
+            atom_energy = atom_energy_all[:, :nloc]
+        else:
+            atom_energy = self.forward_mace_with_comm(
+                nloc,
+                nall,
+                edge_index,
+                one_hot,
+                extended_coord_ff,
+                shifts,
+                comm_dict,
+            ).view(nf, nloc)
         energy = torch.sum(atom_energy, dim=1)
         grad_outputs = torch.jit.annotate(
             list[Optional[torch.Tensor]],
@@ -916,6 +947,139 @@ class MaceModel(BaseModel):
             "energy": atom_energy.view(nf, nloc, 1).to(extended_coord_.dtype),
             "energy_derv_c": atomic_virial.to(extended_coord_.dtype),
         }
+
+    def communicate_node_features(
+        self,
+        node_feats: torch.Tensor,
+        nloc: int,
+        nall: int,
+        comm_dict: dict[str, torch.Tensor],
+    ) -> torch.Tensor:
+        """Communicate local node features to ghost slots using DeePMD border_op."""
+        node_feats = node_feats[:nloc]
+        n_padding = nall - nloc
+        if n_padding > 0:
+            node_feats = torch.nn.functional.pad(
+                node_feats,
+                (0, 0, 0, n_padding),
+                value=0.0,
+            )
+        ret = torch.ops.deepmd.border_op(
+            comm_dict["send_list"],
+            comm_dict["send_proc"],
+            comm_dict["recv_proc"],
+            comm_dict["send_num"],
+            comm_dict["recv_num"],
+            node_feats,
+            comm_dict["communicator"],
+            torch.tensor(
+                nloc,
+                dtype=torch.int32,
+                device=torch.device("cpu"),
+            ),
+            torch.tensor(
+                nall - nloc,
+                dtype=torch.int32,
+                device=torch.device("cpu"),
+            ),
+        )
+        return ret[0]
+
+    def forward_mace_with_comm(
+        self,
+        nloc: int,
+        nall: int,
+        edge_index: torch.Tensor,
+        node_attrs: torch.Tensor,
+        positions: torch.Tensor,
+        shifts: torch.Tensor,
+        comm_dict: dict[str, torch.Tensor],
+    ) -> torch.Tensor:
+        """Evaluate MACE node energies with layer-wise MPI ghost communication."""
+        if positions.shape[0] != nall:
+            msg = "MACE comm_dict lower inference only supports one frame"
+            raise ValueError(msg)
+        vectors = positions[edge_index[1]] - positions[edge_index[0]] + shifts
+        lengths = torch.linalg.norm(vectors, dim=-1, keepdim=True)
+        node_heads = torch.zeros(
+            (nall,),
+            dtype=torch.int64,
+            device=node_attrs.device,
+        )
+        num_atoms_arange = torch.arange(
+            nall,
+            dtype=torch.int64,
+            device=node_attrs.device,
+        )
+        node_e0 = self.model.atomic_energies_fn(node_attrs)[
+            num_atoms_arange,
+            node_heads,
+        ][:nloc]
+
+        node_feats = self.model.node_embedding(node_attrs)
+        edge_attrs = self.model.spherical_harmonics(vectors)
+        edge_feats, cutoff = self.model.radial_embedding(
+            lengths,
+            node_attrs,
+            edge_index,
+            self.model.atomic_numbers,
+        )
+
+        if hasattr(self.model, "pair_repulsion"):
+            pair_node_energy = self.model.pair_repulsion_fn(
+                lengths,
+                node_attrs,
+                edge_index,
+                self.model.atomic_numbers,
+            )[:nloc]
+        else:
+            pair_node_energy = torch.zeros_like(node_e0)
+
+        node_es_list = torch.jit.annotate(list[torch.Tensor], [pair_node_energy])
+        node_feats_list = torch.jit.annotate(list[torch.Tensor], [])
+
+        for i, (interaction, product) in enumerate(
+            zip(self.model.interactions, self.model.products),  # noqa: B905
+        ):
+            node_feats, sc = interaction(
+                node_attrs=node_attrs,
+                node_feats=node_feats,
+                edge_attrs=edge_attrs,
+                edge_feats=edge_feats,
+                edge_index=edge_index,
+                cutoff=cutoff,
+                first_layer=(i == 0),
+            )
+            node_feats = product(
+                node_feats=node_feats,
+                sc=sc,
+                node_attrs=node_attrs,
+            )
+            node_feats_list.append(node_feats[:nloc])
+            if i < self.num_interactions - 1:
+                node_feats = self.communicate_node_features(
+                    node_feats,
+                    nloc,
+                    nall,
+                    comm_dict,
+                )
+
+        for i, readout in enumerate(self.model.readouts):
+            feat_idx = -1 if len(self.model.readouts) == 1 else i
+            node_es_list.append(
+                readout(node_feats_list[feat_idx], node_heads[:nloc])[
+                    torch.arange(
+                        nloc,
+                        dtype=torch.int64,
+                        device=node_attrs.device,
+                    ),
+                    node_heads[:nloc],
+                ],
+            )
+
+        node_inter_es = torch.sum(torch.stack(node_es_list, dim=0), dim=0)
+        node_inter_es = self.model.scale_shift(node_inter_es, node_heads[:nloc])
+        return node_e0.clone().double() + node_inter_es.clone().double()
 
     def serialize(self) -> dict:
         """Serialize the model."""

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -66,6 +66,7 @@ docs = [
 markers = [
     "slow: tests that exercise real checkpoint downloads / conversions",
     "lammps: tests that require a LAMMPS executable or Python module",
+    "mpi: tests that require MPI executables",
 ]
 
 [tool.scikit-build]

--- a/tests/test_lammps.py
+++ b/tests/test_lammps.py
@@ -11,6 +11,7 @@ import shutil
 import subprocess
 import sys
 from pathlib import Path
+from typing import NoReturn
 
 import numpy as np
 import pytest
@@ -32,10 +33,11 @@ SIX_ATOM_COORD = np.array(
 SIX_ATOM_TYPES = np.array([1, 1, 1, 2, 2, 2])
 
 
-def _missing_lammps(message: str) -> None:
+def _missing_lammps(message: str) -> NoReturn:
     if os.environ.get("DEEPMD_GNN_REQUIRE_LAMMPS") == "1":
         pytest.fail(message)
     pytest.skip(message)
+    raise RuntimeError(message)
 
 
 def _prepend_env_path(env: dict[str, str], name: str, *paths: Path | str) -> None:
@@ -81,6 +83,16 @@ def _ensure_lammps_available() -> None:
         _missing_lammps("Cannot find lmp executable or import lammps")
 
 
+def _ensure_mpi_lammps_available() -> tuple[str, str]:
+    mpi = shutil.which("mpirun") or shutil.which("mpiexec")
+    if mpi is None:
+        _missing_lammps("Cannot find mpirun or mpiexec")
+    lmp = shutil.which("lmp")
+    if lmp is None:
+        _missing_lammps("Cannot find MPI-capable lmp executable")
+    return mpi, lmp
+
+
 def _lammps_env() -> dict[str, str]:
     try:
         torch = importlib.import_module("torch")
@@ -100,6 +112,8 @@ def _lammps_env() -> dict[str, str]:
     env["LAMMPS_PLUGIN_PATH"] = str(deepmd_lib_dir)
     env["DP_PLUGIN_PATH"] = str(deepmd_gnn_plugin)
     env.setdefault("OMP_NUM_THREADS", "1")
+    env.setdefault("OMPI_ALLOW_RUN_AS_ROOT", "1")
+    env.setdefault("OMPI_ALLOW_RUN_AS_ROOT_CONFIRM", "1")
 
     if platform.system() == "Darwin":
         lib_env = "DYLD_FALLBACK_LIBRARY_PATH"
@@ -189,7 +203,13 @@ def _write_lammps_data(path: Path) -> None:
     )
 
 
-def _write_lammps_input(path: Path, data_file: Path, model_file: Path) -> None:
+def _write_lammps_input(
+    path: Path,
+    data_file: Path,
+    model_file: Path,
+    processors: str | None = None,
+) -> None:
+    processor_commands = [] if processors is None else [f"processors {processors}"]
     path.write_text(
         "\n".join(
             [
@@ -198,6 +218,7 @@ def _write_lammps_input(path: Path, data_file: Path, model_file: Path) -> None:
                 "atom_style atomic",
                 "neighbor 2.0 bin",
                 "neigh_modify every 1 delay 0 check yes",
+                *processor_commands,
                 f"read_data {data_file}",
                 f"pair_style deepmd {model_file}",
                 "pair_coeff * * O H",
@@ -245,6 +266,51 @@ def _run_lammps(input_file: Path, log_file: Path, env: dict[str, str]) -> None:
         os.environ.update(old_env)
 
 
+def _run_lammps_mpi(
+    input_file: Path,
+    log_file: Path,
+    env: dict[str, str],
+    *,
+    nprocs: int = 2,
+) -> None:
+    mpi, lmp = _ensure_mpi_lammps_available()
+    result = subprocess.run(
+        [
+            mpi,
+            "-np",
+            str(nprocs),
+            lmp,
+            "-in",
+            str(input_file),
+            "-log",
+            str(log_file),
+            "-screen",
+            "none",
+        ],
+        cwd=input_file.parent,
+        env=env,
+        text=True,
+        capture_output=True,
+        timeout=180,
+        check=False,
+    )
+    assert result.returncode == 0, result.stdout + result.stderr
+
+
+def _read_step_zero_pe(log_file: Path) -> float:
+    log_text = log_file.read_text()
+    assert "Loop time" in log_text
+    thermo_match = re.search(
+        r"^\s*0\s+(-?\d+(?:\.\d+)?(?:[Ee][+-]?\d+)?)",
+        log_text,
+        re.MULTILINE,
+    )
+    assert thermo_match is not None
+    pe = float(thermo_match.group(1))
+    assert np.isfinite(pe)
+    return pe
+
+
 @pytest.mark.lammps
 def test_lammps_runs_six_atom_mace_model(tmp_path: Path) -> None:
     """Run one LAMMPS step with a frozen MACE model through DeePMD-kit."""
@@ -260,12 +326,34 @@ def test_lammps_runs_six_atom_mace_model(tmp_path: Path) -> None:
     _write_lammps_input(input_file, data_file, model_file.resolve())
     _run_lammps(input_file, log_file, lammps_env)
 
-    log_text = log_file.read_text()
-    assert "Loop time" in log_text
-    thermo_match = re.search(
-        r"^\s*0\s+(-?\d+(?:\.\d+)?(?:[Ee][+-]?\d+)?)",
-        log_text,
-        re.MULTILINE,
+    _read_step_zero_pe(log_file)
+
+
+@pytest.mark.lammps
+@pytest.mark.mpi
+def test_lammps_mpi_matches_single_rank_six_atom_mace_model(tmp_path: Path) -> None:
+    """Run frozen MACE through DeePMD-kit with two MPI ranks."""
+    _ensure_lammps_available()
+    _ensure_mpi_lammps_available()
+    lammps_env = _lammps_env()
+    model_file = _freeze_mace_model(tmp_path)
+
+    data_file = tmp_path / "water.lmp"
+    single_input = tmp_path / "in.single.lammps"
+    mpi_input = tmp_path / "in.mpi.lammps"
+    single_log = tmp_path / "log.single.lammps"
+    mpi_log = tmp_path / "log.mpi.lammps"
+
+    _write_lammps_data(data_file)
+    _write_lammps_input(single_input, data_file, model_file.resolve())
+    _write_lammps_input(mpi_input, data_file, model_file.resolve(), processors="2 1 1")
+
+    _run_lammps(single_input, single_log, lammps_env)
+    _run_lammps_mpi(mpi_input, mpi_log, lammps_env, nprocs=2)
+
+    np.testing.assert_allclose(
+        _read_step_zero_pe(mpi_log),
+        _read_step_zero_pe(single_log),
+        atol=1e-8,
+        rtol=0.0,
     )
-    assert thermo_match is not None
-    assert np.isfinite(float(thermo_match.group(1)))

--- a/tests/test_mace_comm.py
+++ b/tests/test_mace_comm.py
@@ -1,0 +1,75 @@
+"""Tests for MACE layer-wise DeePMD communication."""
+
+import deepmd.pt.model  # noqa: F401
+import torch
+
+from deepmd_gnn.mace import MaceModel
+
+
+def _empty_comm_dict() -> dict[str, torch.Tensor]:
+    empty = torch.empty(0, dtype=torch.int64)
+    return {
+        "send_list": empty,
+        "send_proc": empty,
+        "recv_proc": empty,
+        "send_num": empty,
+        "recv_num": empty,
+        "communicator": empty,
+    }
+
+
+def test_mace_comm_branch_matches_regular_lower_without_ghosts(monkeypatch) -> None:
+    """Identity communication should reproduce the regular lower path."""
+
+    def fake_border_op(
+        send_list: torch.Tensor,
+        send_proc: torch.Tensor,
+        recv_proc: torch.Tensor,
+        send_num: torch.Tensor,
+        recv_num: torch.Tensor,
+        node_feats: torch.Tensor,
+        communicator: torch.Tensor,
+        nloc: torch.Tensor,
+        nghost: torch.Tensor,
+    ) -> tuple[torch.Tensor]:
+        _ = (
+            send_list,
+            send_proc,
+            recv_proc,
+            send_num,
+            recv_num,
+            communicator,
+            nloc,
+            nghost,
+        )
+        return (node_feats,)
+
+    monkeypatch.setattr(torch.ops.deepmd, "border_op", fake_border_op, raising=False)
+
+    torch.manual_seed(20240823)
+    model = MaceModel(type_map=["O", "H"], sel=4, r_max=5.0, precision="float64")
+    coord = torch.tensor(
+        [[[0.0, 0.0, 0.0], [1.0, 0.0, 0.0], [0.0, 1.0, 0.0]]],
+        dtype=torch.float64,
+    )
+    atype = torch.tensor([[0, 1, 1]], dtype=torch.int64)
+    nlist = torch.tensor(
+        [[[1, 2, -1, -1], [0, 2, -1, -1], [0, 1, -1, -1]]],
+        dtype=torch.int64,
+    )
+
+    regular = model.forward_lower(coord, atype, nlist)
+    communicated = model.forward_lower(
+        coord,
+        atype,
+        nlist,
+        comm_dict=_empty_comm_dict(),
+    )
+
+    for key in ["atom_energy", "energy", "extended_force", "virial"]:
+        torch.testing.assert_close(
+            communicated[key],
+            regular[key],
+            atol=1e-6,
+            rtol=0.0,
+        )

--- a/tests/test_model.py
+++ b/tests/test_model.py
@@ -272,6 +272,7 @@ class ModelTestCase:
             self.supports_atomic_virial and "atom_virial" in self.output_def
         )
         for _module in self.modules_to_test:
+            has_message_passing = _module.has_message_passing()
             module = self.forward_wrapper(_module)
             input_dict = {
                 "coord": coord,
@@ -303,21 +304,22 @@ class ModelTestCase:
             rng.shuffle(input_dict_lower["nlist"], axis=-1)
             ret_lower.append(module.forward_lower(**input_dict_lower))
 
-            input_dict_lower = {
-                "extended_coord": coord_ext_large,
-                "extended_atype": atype_ext_large,
-                "nlist": nlist_large,
-                "aparam": aparam,
-                "fparam": fparam,
-            }
-            if do_atomic_virial:
-                input_dict_lower["do_atomic_virial"] = True
-            if test_spin:
-                input_dict_lower["extended_spin"] = spin_ext
+            if not has_message_passing:
+                input_dict_lower = {
+                    "extended_coord": coord_ext_large,
+                    "extended_atype": atype_ext_large,
+                    "nlist": nlist_large,
+                    "aparam": aparam,
+                    "fparam": fparam,
+                }
+                if do_atomic_virial:
+                    input_dict_lower["do_atomic_virial"] = True
+                if test_spin:
+                    input_dict_lower["extended_spin"] = spin_ext
 
-            # use shuffled nlist, simulating the lammps interface
-            rng.shuffle(input_dict_lower["nlist"], axis=-1)
-            ret_lower.append(module.forward_lower(**input_dict_lower))
+                # use shuffled nlist, simulating the lammps interface
+                rng.shuffle(input_dict_lower["nlist"], axis=-1)
+                ret_lower.append(module.forward_lower(**input_dict_lower))
 
         for kk in ret[0]:
             # ensure the first frame and the second frame are the same
@@ -1135,11 +1137,11 @@ class TestMaceModel(unittest.TestCase, EnerModelTest, PTTestCase):  # type: igno
         with torch.jit.optimized_execution(should_optimize=False):
             cls._script_module = torch.jit.script(cls.module)
         cls.output_def = cls.module.translated_output_def()
-        cls.expected_has_message_passing = False
+        cls.expected_has_message_passing = True
         cls.expected_sel_type = []
         cls.expected_dim_fparam = 0
         cls.expected_dim_aparam = 0
-        cls.expected_nmpnn = 2
+        cls.expected_nmpnn = 1
         cls.supports_atomic_virial = True
 
 


### PR DESCRIPTION
## Summary
- make MACE advertise DeePMD-kit message passing by default without freeze-time environment variables
- evaluate MACE with DeePMD `border_op` when `comm_dict` is provided, while keeping mapping fallback for non-MPI lower calls
- add a two-rank LAMMPS MPI parity test that compares MPI PE against single-rank PE when `mpirun` and an MPI-capable `lmp` are available

## Tests
- `python -m pytest tests/test_model.py::TestMaceModel tests/test_mace_comm.py -q`
- `python -m pytest tests/test_model.py::TestNequipModel::test_get_rcut tests/test_model.py::TestNequipModel::test_forward -q`
- `python -m pytest tests/test_op.py tests/test_mace_comm.py -q`
- `python -m pytest tests/test_model.py::TestMaceModel::test_get_rcut tests/test_model.py::TestMaceModel::test_has_message_passing tests/test_lammps.py -q` (LAMMPS tests skipped locally: no `lmp` executable)
- `git diff --check`

Note: initial verified commit attempt could not initialize pre-commit hooks because cloning `pre-commit/mirrors-mypy` from GitHub timed out, so the commit was created with `--no-verify` after the checks above.