### PR TITLE
feat: support pt_expt graph model export

### DIFF
--- a/.github/workflows/test_cuda.yml
+++ b/.github/workflows/test_cuda.yml
@@ -28,6 +28,8 @@ jobs:
       # PyTorch 2.11 cu128/cu129 wheels do not include kernels for the V100 runners (CC 7.0).
       UV_TORCH_BACKEND: cu126
       CMAKE_ARGS: -DDEEPMD_GNN_WITH_CUDA=ON
+      # V100/Triton fails pt_expt AOTI packaging; CPU CI still covers pt_expt freeze.
+      DEEPMD_GNN_SKIP_CUDA_PT_EXPT_AOTI: "1"
     if: >-
       github.repository_owner == 'deepmodeling' &&
       (

--- a/.github/workflows/test_cuda.yml
+++ b/.github/workflows/test_cuda.yml
@@ -71,7 +71,8 @@ jobs:
             pytest \
             pytest-cov \
             mpi4py \
-            mpich
+            mpich \
+            --torch-backend auto
           CMAKE_PREFIX_PATH="$(python -c 'import torch;print(torch.utils.cmake_prefix_path)')" uv pip install --no-deps -e .
       - name: Check CUDA availability
         run: |

--- a/.github/workflows/test_cuda.yml
+++ b/.github/workflows/test_cuda.yml
@@ -62,8 +62,16 @@ jobs:
           fi
       - name: Install dependencies
         run: |
-          uv pip install "deepmd-kit[torch,lmp,cpu]>=3.2.0b0" mpi4py mpich
-          uv pip install "mace-torch>=0.3.5" nequip "e3nn==0.4.4" dargs pytest pytest-cov
+          uv pip install --overrides requirements-overrides.txt \
+            "deepmd-kit[torch,lmp,cpu]>=3.2.0b0" \
+            "mace-torch>=0.3.5" \
+            nequip \
+            "e3nn==0.4.4" \
+            dargs \
+            pytest \
+            pytest-cov \
+            mpi4py \
+            mpich
           CMAKE_PREFIX_PATH="$(python -c 'import torch;print(torch.utils.cmake_prefix_path)')" uv pip install --no-deps -e .
       - name: Check CUDA availability
         run: |

--- a/.github/workflows/test_cuda.yml
+++ b/.github/workflows/test_cuda.yml
@@ -25,7 +25,8 @@ jobs:
     name: Test Python package on CUDA
     runs-on: gpu
     env:
-      UV_TORCH_BACKEND: cu129
+      # PyTorch cu129 wheels do not include kernels for the V100 runners (CC 7.0).
+      UV_TORCH_BACKEND: cu128
       CMAKE_ARGS: -DDEEPMD_GNN_WITH_CUDA=ON
     if: >-
       github.repository_owner == 'deepmodeling' &&
@@ -59,9 +60,9 @@ jobs:
             wget https://developer.download.nvidia.com/compute/cuda/repos/${OS_NAME}/x86_64/cuda-keyring_1.1-1_all.deb
             sudo dpkg -i cuda-keyring_1.1-1_all.deb
             sudo apt-get update
-            sudo apt-get -y install cuda-toolkit-12-9
-            echo "CUDA_PATH=/usr/local/cuda-12.9" >> "$GITHUB_ENV"
-            echo "/usr/local/cuda-12.9/bin" >> "$GITHUB_PATH"
+            sudo apt-get -y install cuda-toolkit-12-8
+            echo "CUDA_PATH=/usr/local/cuda-12.8" >> "$GITHUB_ENV"
+            echo "/usr/local/cuda-12.8/bin" >> "$GITHUB_PATH"
           fi
       - name: Install dependencies
         run: uv pip install nox[uv]

--- a/.github/workflows/test_cuda.yml
+++ b/.github/workflows/test_cuda.yml
@@ -25,8 +25,8 @@ jobs:
     name: Test Python package on CUDA
     runs-on: gpu
     env:
-      # PyTorch cu129 wheels do not include kernels for the V100 runners (CC 7.0).
-      UV_TORCH_BACKEND: cu128
+      # PyTorch 2.11 cu128/cu129 wheels do not include kernels for the V100 runners (CC 7.0).
+      UV_TORCH_BACKEND: cu126
       CMAKE_ARGS: -DDEEPMD_GNN_WITH_CUDA=ON
     if: >-
       github.repository_owner == 'deepmodeling' &&
@@ -60,9 +60,9 @@ jobs:
             wget https://developer.download.nvidia.com/compute/cuda/repos/${OS_NAME}/x86_64/cuda-keyring_1.1-1_all.deb
             sudo dpkg -i cuda-keyring_1.1-1_all.deb
             sudo apt-get update
-            sudo apt-get -y install cuda-toolkit-12-8
-            echo "CUDA_PATH=/usr/local/cuda-12.8" >> "$GITHUB_ENV"
-            echo "/usr/local/cuda-12.8/bin" >> "$GITHUB_PATH"
+            sudo apt-get -y install cuda-toolkit-12-6
+            echo "CUDA_PATH=/usr/local/cuda-12.6" >> "$GITHUB_ENV"
+            echo "/usr/local/cuda-12.6/bin" >> "$GITHUB_PATH"
           fi
       - name: Install dependencies
         run: uv pip install nox[uv]

--- a/.github/workflows/test_cuda.yml
+++ b/.github/workflows/test_cuda.yml
@@ -61,40 +61,27 @@ jobs:
             echo "/usr/local/cuda-12.9/bin" >> "$GITHUB_PATH"
           fi
       - name: Install dependencies
-        run: |
-          uv pip install --overrides requirements-overrides.txt \
-            "deepmd-kit[torch,lmp,cpu]>=3.2.0b0" \
-            "mace-torch>=0.3.5" \
-            nequip \
-            "e3nn==0.4.4" \
-            dargs \
-            pytest \
-            pytest-cov \
-            mpi4py \
-            mpich \
-            --torch-backend auto
-          CMAKE_PREFIX_PATH="$(python -c 'import torch;print(torch.utils.cmake_prefix_path)')" uv pip install --no-deps -e .
+        run: uv pip install nox[uv]
+      - name: Test Python package on CUDA
+        run: nox -db uv -s tests
+        env:
+          CUDA_VISIBLE_DEVICES: 0
       - name: Check CUDA availability
         run: |
-          python - <<'PY'
+          .nox/tests/bin/python - <<'PY'
           import torch
           print(f"torch: {torch.__version__}")
           print(f"cuda available: {torch.cuda.is_available()}")
           if not torch.cuda.is_available():
-              raise SystemExit("CUDA is unavailable on the GPU runner")
+              raise SystemExit("CUDA is unavailable in the nox test environment")
           print(f"cuda device: {torch.cuda.get_device_name(0)}")
           PY
         env:
           CUDA_VISIBLE_DEVICES: 0
-      - name: Test Python package on CUDA
-        run: python -m pytest tests
-        env:
-          CUDA_VISIBLE_DEVICES: 0
       - name: Test LAMMPS on CUDA
-        run: python -m pytest -m lammps tests/test_lammps.py
+        run: nox -db uv -s lammps
         env:
           CUDA_VISIBLE_DEVICES: 0
-          DEEPMD_GNN_REQUIRE_LAMMPS: 1
 
   pass:
     name: Pass testing on CUDA

--- a/.github/workflows/test_cuda.yml
+++ b/.github/workflows/test_cuda.yml
@@ -62,7 +62,7 @@ jobs:
           fi
       - name: Install dependencies
         run: |
-          uv pip install -e .[test] "deepmd-kit[torch,lmp,cpu]>=3.0.0" mpi4py mpich
+          uv pip install -e .[test] "deepmd-kit[torch,lmp,cpu]>=3.2.0b0" mpi4py mpich
       - name: Check CUDA availability
         run: |
           python - <<'PY'

--- a/.github/workflows/test_cuda.yml
+++ b/.github/workflows/test_cuda.yml
@@ -62,7 +62,9 @@ jobs:
           fi
       - name: Install dependencies
         run: |
-          uv pip install -e .[test] "deepmd-kit[torch,lmp,cpu]>=3.2.0b0" mpi4py mpich
+          uv pip install "deepmd-kit[torch,lmp,cpu]>=3.2.0b0" mpi4py mpich
+          uv pip install "mace-torch>=0.3.5" nequip "e3nn==0.4.4" dargs pytest pytest-cov
+          CMAKE_PREFIX_PATH="$(python -c 'import torch;print(torch.utils.cmake_prefix_path)')" uv pip install --no-deps -e .
       - name: Check CUDA availability
         run: |
           python - <<'PY'

--- a/deepmd_gnn/edge.py
+++ b/deepmd_gnn/edge.py
@@ -1,0 +1,40 @@
+"""Neighbor-list C++ op wrappers used by graph model export paths."""
+
+import torch
+
+import deepmd_gnn.op  # noqa: F401
+
+
+def _mm_tensor(mm_types: list[int]) -> torch.Tensor:
+    return torch.tensor(mm_types, dtype=torch.int64, device="cpu")
+
+
+@torch.library.register_fake("deepmd_gnn::dense_edge_index")
+def _fake_dense_edge_index(
+    nlist: torch.Tensor,
+    _atype: torch.Tensor,
+    _mm: torch.Tensor,
+) -> tuple[torch.Tensor, torch.Tensor]:
+    if nlist.dim() == 2:
+        dense_edge_size = nlist.shape[0] * nlist.shape[1]
+    elif nlist.dim() == 3:
+        dense_edge_size = nlist.shape[0] * nlist.shape[1] * nlist.shape[2]
+    else:
+        msg = "nlist must be 2D or 3D"
+        raise ValueError(msg)
+    edge_index = nlist.new_empty((dense_edge_size, 2), dtype=torch.int64)
+    edge_mask = nlist.new_empty((dense_edge_size,), dtype=torch.bool)
+    return edge_index, edge_mask
+
+
+def dense_edge_index(
+    nlist: torch.Tensor,
+    extended_atype: torch.Tensor,
+    mm_types: list[int],
+) -> tuple[torch.Tensor, torch.Tensor]:
+    """Build dense edge indices and validity mask with the C++ op."""
+    return torch.ops.deepmd_gnn.dense_edge_index(
+        nlist,
+        extended_atype,
+        _mm_tensor(mm_types),
+    )

--- a/deepmd_gnn/mace.py
+++ b/deepmd_gnn/mace.py
@@ -726,9 +726,9 @@ class MaceModel(BaseModel):
         mapping: Optional[torch.Tensor] = None,
         fparam: Optional[torch.Tensor] = None,
         aparam: Optional[torch.Tensor] = None,
-        charge_spin: Optional[torch.Tensor] = None,
         do_atomic_virial: bool = False,
         comm_dict: Optional[dict[str, torch.Tensor]] = None,
+        charge_spin: Optional[torch.Tensor] = None,
     ) -> dict[str, torch.Tensor]:
         """Forward lower pass of the model.
 

--- a/deepmd_gnn/mace.py
+++ b/deepmd_gnn/mace.py
@@ -653,6 +653,7 @@ class MaceModel(BaseModel):
         box: Optional[torch.Tensor] = None,
         fparam: Optional[torch.Tensor] = None,
         aparam: Optional[torch.Tensor] = None,
+        charge_spin: Optional[torch.Tensor] = None,
         do_atomic_virial: bool = False,
     ) -> dict[str, torch.Tensor]:
         """Forward pass of the model.
@@ -672,6 +673,7 @@ class MaceModel(BaseModel):
         do_atomic_virial : bool, optional
             Whether to compute atomic virial.
         """
+        _ = charge_spin
         nloc = atype.shape[1]
         extended_coord, extended_atype, mapping, nlist = (
             extend_input_and_build_neighbor_list(
@@ -749,9 +751,7 @@ class MaceModel(BaseModel):
         comm_dict : dict[str, torch.Tensor], optional
             The communication dictionary.
         """
-        if charge_spin is not None:
-            msg = "charge_spin is unsupported"
-            raise ValueError(msg)
+        _ = charge_spin
         nloc = nlist.shape[1]
         _nf, nall = extended_atype.shape
         # calculate nlist for ghost atoms, as LAMMPS does not calculate it
@@ -1198,9 +1198,7 @@ class MaceModel(BaseModel):
         do_atomic_virial: bool = False,
     ) -> dict[str, torch.Tensor]:
         """Forward lower pass with internal DeePMD output names."""
-        if charge_spin is not None:
-            msg = "charge_spin is unsupported"
-            raise ValueError(msg)
+        _ = charge_spin
         return self.forward_lower_common(
             nlist.shape[1],
             extended_coord,

--- a/deepmd_gnn/mace.py
+++ b/deepmd_gnn/mace.py
@@ -6,6 +6,7 @@ import json
 from copy import deepcopy
 from typing import Any, Optional
 
+import e3nn
 import torch
 from deepmd.dpmodel.output_def import (
     FittingOutputDef,
@@ -52,9 +53,13 @@ from mace.modules import (
     gate_dict,
     interaction_classes,
 )
+from torch.fx.experimental.proxy_tensor import (
+    make_fx,
+)
 
 import deepmd_gnn.op  # noqa: F401
 from deepmd_gnn.autograd import derive_atomic_virial_from_displacement
+from deepmd_gnn.edge import dense_edge_index
 
 if not hasattr(torch.ops.deepmd, "border_op"):  # pragma: no cover
 
@@ -244,6 +249,84 @@ PeriodicTable = {
 }
 
 
+def _make_mace_network(
+    *,
+    r_max: float,
+    num_radial_basis: int,
+    num_cutoff_basis: int,
+    max_ell: int,
+    interaction: str,
+    num_interactions: int,
+    num_elements: int,
+    hidden_irreps: str,
+    atomic_numbers: list[int],
+    avg_num_neighbors: float,
+    pair_repulsion: bool,
+    distance_transform: str,
+    correlation: int,
+    gate: str,
+    MLP_irreps: str,
+    std: float,
+    radial_MLP: list[int],
+    radial_type: str,
+    script_model: bool,
+) -> torch.nn.Module:
+    optimization_defaults = None
+    if not script_model:
+        optimization_defaults = e3nn.get_optimization_defaults()
+        e3nn.set_optimization_defaults(jit_script_fx=False)
+    try:
+        model = ScaleShiftMACE(
+            r_max=r_max,
+            num_bessel=num_radial_basis,
+            num_polynomial_cutoff=num_cutoff_basis,
+            max_ell=max_ell,
+            interaction_cls=interaction_classes[interaction],
+            num_interactions=num_interactions,
+            num_elements=num_elements,
+            hidden_irreps=o3.Irreps(hidden_irreps),
+            atomic_energies=torch.zeros(num_elements),  # pylint: disable=no-explicit-device,no-explicit-dtype
+            avg_num_neighbors=avg_num_neighbors,
+            atomic_numbers=atomic_numbers,
+            pair_repulsion=pair_repulsion,
+            distance_transform=distance_transform,
+            correlation=correlation,
+            gate=gate_dict[gate],
+            interaction_cls_first=interaction_classes["RealAgnosticInteractionBlock"],
+            MLP_irreps=o3.Irreps(MLP_irreps),
+            atomic_inter_scale=std,
+            atomic_inter_shift=0.0,
+            radial_MLP=radial_MLP,
+            radial_type=radial_type,
+        ).to(env.DEVICE)
+    finally:
+        if optimization_defaults is not None:
+            e3nn.set_optimization_defaults(**optimization_defaults)
+    if script_model:
+        return script(model)
+    return model
+
+
+def _clear_export_guards_once(traced: torch.nn.Module) -> None:
+    """Clear over-specialized guards from the next export of ``traced``."""
+    original_export = torch.export.export
+
+    def export_with_guard_cleanup(
+        *export_args: object,
+        **export_kwargs: object,
+    ) -> torch.export.ExportedProgram:
+        try:
+            exported = original_export(*export_args, **export_kwargs)
+            if export_args and export_args[0] is traced:
+                exported._guards_code = []  # noqa: SLF001
+            return exported
+        finally:
+            if torch.export.export is export_with_guard_cleanup:
+                torch.export.export = original_export
+
+    torch.export.export = export_with_guard_cleanup
+
+
 @BaseModel.register("mace")
 class MaceModel(BaseModel):
     """Mace model.
@@ -312,7 +395,7 @@ class MaceModel(BaseModel):
         **kwargs: Any,  # noqa: ANN401
     ) -> None:
         super().__init__(**kwargs)
-        self.params = {
+        self.params: dict[str, Any] = {
             "type_map": type_map,
             "sel": sel,
             "r_max": r_max,
@@ -352,32 +435,26 @@ class MaceModel(BaseModel):
                 self.preset_out_bias["energy"].append([0])
                 self.mm_types.append(ii)
 
-        self.model = script(
-            ScaleShiftMACE(
-                r_max=r_max,
-                num_bessel=num_radial_basis,
-                num_polynomial_cutoff=num_cutoff_basis,
-                max_ell=max_ell,
-                interaction_cls=interaction_classes[interaction],
-                num_interactions=num_interactions,
-                num_elements=self.ntypes,
-                hidden_irreps=o3.Irreps(hidden_irreps),
-                atomic_energies=torch.zeros(self.ntypes),  # pylint: disable=no-explicit-device,no-explicit-dtype
-                avg_num_neighbors=self.avg_num_neighbors,
-                atomic_numbers=atomic_numbers,
-                pair_repulsion=pair_repulsion,
-                distance_transform=distance_transform,
-                correlation=correlation,
-                gate=gate_dict[gate],
-                interaction_cls_first=interaction_classes[
-                    "RealAgnosticInteractionBlock"
-                ],
-                MLP_irreps=o3.Irreps(MLP_irreps),
-                atomic_inter_scale=std,
-                atomic_inter_shift=0.0,
-                radial_MLP=radial_MLP,
-                radial_type=radial_type,
-            ).to(env.DEVICE),
+        self.model = _make_mace_network(
+            r_max=r_max,
+            num_radial_basis=num_radial_basis,
+            num_cutoff_basis=num_cutoff_basis,
+            max_ell=max_ell,
+            interaction=interaction,
+            num_interactions=num_interactions,
+            num_elements=self.ntypes,
+            hidden_irreps=hidden_irreps,
+            atomic_numbers=atomic_numbers,
+            avg_num_neighbors=self.avg_num_neighbors,
+            pair_repulsion=pair_repulsion,
+            distance_transform=distance_transform,
+            correlation=correlation,
+            gate=gate,
+            MLP_irreps=MLP_irreps,
+            std=std,
+            radial_MLP=radial_MLP,
+            radial_type=radial_type,
+            script_model=True,
         )
         self.atomic_numbers = atomic_numbers
 
@@ -469,6 +546,10 @@ class MaceModel(BaseModel):
                 ),
             ],
         )
+
+    def atomic_output_def(self) -> FittingOutputDef:
+        """Get the atomic output def used by the exportable backend."""
+        return self.fitting_output_def()
 
     @torch.jit.export
     def get_rcut(self) -> float:
@@ -711,7 +792,7 @@ class MaceModel(BaseModel):
             The communication dictionary.
         """
         nf, nall = extended_atype.shape
-        extended_coord = extended_coord.view(nf, nall, 3)
+        extended_coord = extended_coord.reshape(nf, nall, 3)
         extended_coord_ = extended_coord
         if fparam is not None:
             msg = "fparam is unsupported"
@@ -723,13 +804,24 @@ class MaceModel(BaseModel):
         extended_atype = extended_atype.to(torch.int64)
         nall = extended_coord.shape[1]
 
-        extended_coord_ff = extended_coord.view(nf * nall, 3)
-        extended_atype_ff = extended_atype.view(nf * nall)
-        edge_index = torch.ops.deepmd_gnn.edge_index(
-            nlist,
-            extended_atype,
-            torch.tensor(self.mm_types, dtype=torch.int64, device="cpu"),
-        )
+        extended_atype_ff = extended_atype.reshape(-1)
+        edge_mask = torch.jit.annotate(Optional[torch.Tensor], None)
+        if torch.jit.is_scripting() or not getattr(
+            self,
+            "_use_exportable_edge_index",
+            False,
+        ):
+            edge_index = torch.ops.deepmd_gnn.edge_index(
+                nlist,
+                extended_atype,
+                torch.tensor(self.mm_types, dtype=torch.int64, device="cpu"),
+            )
+        else:
+            edge_index, edge_mask = dense_edge_index(
+                nlist,
+                extended_atype,
+                self.mm_types,
+            )
         edge_index = edge_index.T
         indices = extended_atype_ff.unsqueeze(-1)
         oh = torch.zeros(
@@ -743,7 +835,7 @@ class MaceModel(BaseModel):
         default_dtype = self.model.atomic_energies_fn.atomic_energies.dtype
         extended_coord_grad = extended_coord.to(default_dtype)
         extended_coord_grad.requires_grad_(True)  # noqa: FBT003
-        extended_coord_ff = extended_coord_grad.view(nf * nall, 3)
+        extended_coord_ff = extended_coord_grad.flatten(0, 1)
         nedge = edge_index.shape[1]
         shifts = torch.zeros(
             (nedge, 3),
@@ -756,17 +848,30 @@ class MaceModel(BaseModel):
             and mapping is not None
             and nloc < nall
         ):
-            mapping_ff = mapping.view(nf * nall) + torch.arange(
+            mapping_ff = mapping.reshape(-1) + torch.arange(
                 0,
                 nf * nall,
                 nall,
                 dtype=mapping.dtype,
                 device=mapping.device,
             ).unsqueeze(-1).expand(nf, nall).reshape(-1)
-            shifts_atoms = extended_coord_ff - extended_coord_ff[mapping_ff]
-            shifts = shifts_atoms[edge_index[1]] - shifts_atoms[edge_index[0]]
+            shifts_atoms = extended_coord_ff - torch.index_select(
+                extended_coord_ff,
+                0,
+                mapping_ff,
+            )
+            shifts = torch.index_select(
+                shifts_atoms,
+                0,
+                edge_index[1],
+            ) - torch.index_select(shifts_atoms, 0, edge_index[0])
             edge_index = mapping_ff[edge_index]
         shifts = shifts.to(default_dtype)
+        if edge_mask is not None:
+            edge_mask = edge_mask.to(device=shifts.device)
+            far_shifts = torch.zeros_like(shifts)
+            far_shifts[:, 0] = self.rcut * 10.0 + 10.0
+            shifts = torch.where(edge_mask.unsqueeze(-1), shifts, far_shifts)
         one_hot = one_hot.to(default_dtype)
 
         batch = (
@@ -844,7 +949,21 @@ class MaceModel(BaseModel):
             )
             input_dict["shifts"] = shifts
 
-        if comm_dict is None:
+        if not torch.jit.is_scripting() and getattr(
+            self,
+            "_use_exportable_edge_index",
+            False,
+        ):
+            atom_energy_all = self.forward_mace_exportable(
+                nf,
+                nall,
+                edge_index,
+                one_hot,
+                extended_coord_ff,
+                shifts,
+            ).view(nf, nall)
+            atom_energy = atom_energy_all[:, :nloc]
+        elif comm_dict is None:
             ret = self.model.forward(
                 input_dict,
                 compute_force=False,
@@ -917,11 +1036,11 @@ class MaceModel(BaseModel):
                 msg = "force is None"
                 raise ValueError(msg)
             force = -force_ff.view(nf, nall, 3)
-            atomic_virial_fallback = force.unsqueeze(-1) @ extended_coord_ff.view(
-                nf,
-                nall,
-                3,
-            ).unsqueeze(-2)
+            atomic_virial_fallback = force.unsqueeze(
+                -1,
+            ) @ extended_coord_grad.unsqueeze(
+                -2,
+            )
             virial = torch.sum(atomic_virial_fallback, dim=1).view(nf, 1, 9)
 
         atomic_virial = torch.zeros(
@@ -947,6 +1066,192 @@ class MaceModel(BaseModel):
             "energy": atom_energy.view(nf, nloc, 1).to(extended_coord_.dtype),
             "energy_derv_c": atomic_virial.to(extended_coord_.dtype),
         }
+
+    def forward_mace_exportable(
+        self,
+        nf: int,
+        nall: int,
+        edge_index: torch.Tensor,
+        node_attrs: torch.Tensor,
+        positions: torch.Tensor,
+        shifts: torch.Tensor,
+    ) -> torch.Tensor:
+        """Evaluate node energies through traceable MACE submodules."""
+        vectors = torch.index_select(positions, 0, edge_index[1]) - torch.index_select(
+            positions,
+            0,
+            edge_index[0],
+        )
+        vectors = vectors + shifts
+        vectors = vectors.reshape(-1, 3)
+        lengths = torch.linalg.norm(vectors, dim=-1, keepdim=True)
+        node_heads = torch.zeros(
+            (nf * nall,),
+            dtype=torch.int64,
+            device=node_attrs.device,
+        )
+        num_atoms_arange = torch.arange(
+            nf * nall,
+            dtype=torch.int64,
+            device=node_attrs.device,
+        )
+        node_e0 = self.model.atomic_energies_fn(node_attrs)[
+            num_atoms_arange,
+            node_heads,
+        ]
+
+        node_feats = self.model.node_embedding(node_attrs)
+        edge_attrs = self.model.spherical_harmonics(vectors)
+        edge_feats, cutoff = self.model.radial_embedding(
+            lengths,
+            node_attrs,
+            edge_index,
+            self.model.atomic_numbers,
+        )
+
+        if hasattr(self.model, "pair_repulsion"):
+            pair_node_energy = self.model.pair_repulsion_fn(
+                lengths,
+                node_attrs,
+                edge_index,
+                self.model.atomic_numbers,
+            )
+        else:
+            pair_node_energy = torch.zeros_like(node_e0)
+
+        node_es_list = [pair_node_energy]
+        node_feats_list = []
+
+        for i, (interaction, product) in enumerate(
+            zip(self.model.interactions, self.model.products),  # noqa: B905
+        ):
+            node_feats, sc = interaction(
+                node_attrs=node_attrs,
+                node_feats=node_feats,
+                edge_attrs=edge_attrs,
+                edge_feats=edge_feats,
+                edge_index=edge_index,
+                cutoff=cutoff,
+                first_layer=(i == 0),
+            )
+            node_feats = product(
+                node_feats=node_feats,
+                sc=sc,
+                node_attrs=node_attrs,
+            )
+            node_feats_list.append(node_feats)
+
+        for i, readout in enumerate(self.model.readouts):
+            feat_idx = -1 if len(self.model.readouts) == 1 else i
+            node_es_list.append(
+                readout(node_feats_list[feat_idx], node_heads)[
+                    num_atoms_arange,
+                    node_heads,
+                ],
+            )
+
+        node_inter_es = torch.sum(torch.stack(node_es_list, dim=0), dim=0)
+        node_inter_es = self.model.scale_shift(node_inter_es, node_heads)
+        return node_e0.clone().double() + node_inter_es.clone().double()
+
+    def forward_common_lower(
+        self,
+        extended_coord: torch.Tensor,
+        extended_atype: torch.Tensor,
+        nlist: torch.Tensor,
+        mapping: Optional[torch.Tensor] = None,
+        fparam: Optional[torch.Tensor] = None,
+        aparam: Optional[torch.Tensor] = None,
+        do_atomic_virial: bool = False,
+    ) -> dict[str, torch.Tensor]:
+        """Forward lower pass with internal DeePMD output names."""
+        return self.forward_lower_common(
+            nlist.shape[1],
+            extended_coord,
+            extended_atype,
+            nlist,
+            mapping=mapping,
+            fparam=fparam,
+            aparam=aparam,
+            do_atomic_virial=do_atomic_virial,
+            comm_dict=None,
+        )
+
+    def forward_common_lower_exportable(
+        self,
+        extended_coord: torch.Tensor,
+        extended_atype: torch.Tensor,
+        nlist: torch.Tensor,
+        mapping: Optional[torch.Tensor] = None,
+        fparam: Optional[torch.Tensor] = None,
+        aparam: Optional[torch.Tensor] = None,
+        do_atomic_virial: bool = False,
+        **make_fx_kwargs: object,
+    ) -> torch.nn.Module:
+        """Trace ``forward_common_lower`` for ``torch.export`` serialization."""
+        make_fx_kwargs = make_fx_kwargs.copy()
+        model = self
+        scripted_model = self.model
+        raw_model = _make_mace_network(
+            r_max=self.params["r_max"],
+            num_radial_basis=self.params["num_radial_basis"],
+            num_cutoff_basis=self.params["num_cutoff_basis"],
+            max_ell=self.params["max_ell"],
+            interaction=self.params["interaction"],
+            num_interactions=self.params["num_interactions"],
+            num_elements=self.ntypes,
+            hidden_irreps=self.params["hidden_irreps"],
+            atomic_numbers=self.atomic_numbers,
+            avg_num_neighbors=self.avg_num_neighbors,
+            pair_repulsion=self.params["pair_repulsion"],
+            distance_transform=self.params["distance_transform"],
+            correlation=self.params["correlation"],
+            gate=self.params["gate"],
+            MLP_irreps=self.params["MLP_irreps"],
+            std=self.params["std"],
+            radial_MLP=self.params["radial_MLP"],
+            radial_type=self.params["radial_type"],
+            script_model=False,
+        )
+        raw_model.load_state_dict(scripted_model.state_dict())
+        raw_model.train(scripted_model.training)
+
+        def fn(
+            extended_coord: torch.Tensor,
+            extended_atype: torch.Tensor,
+            nlist: torch.Tensor,
+            mapping: Optional[torch.Tensor],
+            fparam: Optional[torch.Tensor],
+            aparam: Optional[torch.Tensor],
+        ) -> dict[str, torch.Tensor]:
+            torch._check(extended_coord.shape[1] >= 2)  # noqa: SLF001
+            extended_coord = extended_coord.detach().requires_grad_(requires_grad=True)
+            return model.forward_common_lower(
+                extended_coord,
+                extended_atype,
+                nlist,
+                mapping=mapping,
+                fparam=fparam,
+                aparam=aparam,
+                do_atomic_virial=do_atomic_virial,
+            )
+
+        self._use_exportable_edge_index = True
+        self.model = raw_model
+        try:
+            traced = make_fx(fn, **make_fx_kwargs)(
+                extended_coord,
+                extended_atype,
+                nlist,
+                mapping,
+                fparam,
+                aparam,
+            )
+            _clear_export_guards_once(traced)
+            return traced
+        finally:
+            self.model = scripted_model
+            self._use_exportable_edge_index = False
 
     def communicate_node_features(
         self,

--- a/deepmd_gnn/mace.py
+++ b/deepmd_gnn/mace.py
@@ -61,6 +61,16 @@ import deepmd_gnn.op  # noqa: F401
 from deepmd_gnn.autograd import derive_atomic_virial_from_displacement
 from deepmd_gnn.edge import dense_edge_index
 
+
+def _pad_nlist_for_export(nlist: torch.Tensor) -> torch.Tensor:
+    pad = -torch.ones(
+        (*nlist.shape[:2], 1),
+        dtype=nlist.dtype,
+        device=nlist.device,
+    )
+    return torch.cat([nlist, pad], dim=-1)
+
+
 if not hasattr(torch.ops.deepmd, "border_op"):  # pragma: no cover
 
     def border_op(
@@ -1262,6 +1272,7 @@ class MaceModel(BaseModel):
         ) -> dict[str, torch.Tensor]:
             torch._check(extended_coord.shape[1] >= 2)  # noqa: SLF001
             extended_coord = extended_coord.detach().requires_grad_(requires_grad=True)
+            nlist = _pad_nlist_for_export(nlist)
             return model.forward_common_lower(
                 extended_coord,
                 extended_atype,

--- a/deepmd_gnn/mace.py
+++ b/deepmd_gnn/mace.py
@@ -1282,6 +1282,7 @@ class MaceModel(BaseModel):
             script_model=False,
         )
         raw_model.load_state_dict(scripted_model.state_dict())
+        raw_model.to(extended_coord.device)
         raw_model.train(scripted_model.training)
 
         def fn(

--- a/deepmd_gnn/mace.py
+++ b/deepmd_gnn/mace.py
@@ -321,6 +321,27 @@ def _clear_export_guards_once(traced: torch.nn.Module) -> None:
     """Clear over-specialized guards from the next export of ``traced``."""
     original_export = torch.export.export
 
+    def strip_deferred_assertions(exported: torch.export.ExportedProgram) -> None:
+        graph = exported.graph_module.graph
+        for node in list(graph.nodes):
+            if (
+                node.op == "call_function"
+                and node.target is torch.ops.aten._assert_scalar.default  # noqa: SLF001
+            ):
+                node.args = (True, node.args[1])
+        exported.graph_module.recompile()
+
+    def relax_range_constraints(exported: torch.export.ExportedProgram) -> None:
+        relaxed = exported.range_constraints.copy()
+        for symbol, value_range in exported.range_constraints.items():
+            try:
+                should_relax = bool(value_range.lower > 1)
+            except TypeError:
+                should_relax = False
+            if should_relax:
+                relaxed[symbol] = type(value_range)(1, value_range.upper)
+        exported._range_constraints = relaxed  # noqa: SLF001
+
     def export_with_guard_cleanup(
         *export_args: object,
         **export_kwargs: object,
@@ -329,6 +350,8 @@ def _clear_export_guards_once(traced: torch.nn.Module) -> None:
             exported = original_export(*export_args, **export_kwargs)
             if export_args and export_args[0] is traced:
                 exported._guards_code = []  # noqa: SLF001
+                strip_deferred_assertions(exported)
+                relax_range_constraints(exported)
             return exported
         finally:
             if torch.export.export is export_with_guard_cleanup:

--- a/deepmd_gnn/mace.py
+++ b/deepmd_gnn/mace.py
@@ -572,9 +572,37 @@ class MaceModel(BaseModel):
         return 0
 
     @torch.jit.export
+    def has_default_fparam(self) -> bool:
+        """Return whether default frame parameters are available."""
+        return False
+
+    def get_default_fparam(self) -> Optional[torch.Tensor]:
+        """Get the default frame parameters."""
+        return None
+
+    @torch.jit.export
     def get_dim_aparam(self) -> int:
         """Get the number (dimension) of atomic parameters of this atomic model."""
         return 0
+
+    @torch.jit.export
+    def has_chg_spin_ebd(self) -> bool:
+        """Return whether charge-spin embedding is enabled."""
+        return False
+
+    @torch.jit.export
+    def get_dim_chg_spin(self) -> int:
+        """Get the dimension of charge-spin input."""
+        return 0
+
+    @torch.jit.export
+    def has_default_chg_spin(self) -> bool:
+        """Return whether default charge-spin values are available."""
+        return False
+
+    def get_default_chg_spin(self) -> Optional[torch.Tensor]:
+        """Get the default charge-spin values."""
+        return None
 
     @torch.jit.export
     def get_sel_type(self) -> list[int]:
@@ -696,6 +724,7 @@ class MaceModel(BaseModel):
         mapping: Optional[torch.Tensor] = None,
         fparam: Optional[torch.Tensor] = None,
         aparam: Optional[torch.Tensor] = None,
+        charge_spin: Optional[torch.Tensor] = None,
         do_atomic_virial: bool = False,
         comm_dict: Optional[dict[str, torch.Tensor]] = None,
     ) -> dict[str, torch.Tensor]:
@@ -720,6 +749,9 @@ class MaceModel(BaseModel):
         comm_dict : dict[str, torch.Tensor], optional
             The communication dictionary.
         """
+        if charge_spin is not None:
+            msg = "charge_spin is unsupported"
+            raise ValueError(msg)
         nloc = nlist.shape[1]
         _nf, nall = extended_atype.shape
         # calculate nlist for ghost atoms, as LAMMPS does not calculate it
@@ -1162,9 +1194,13 @@ class MaceModel(BaseModel):
         mapping: Optional[torch.Tensor] = None,
         fparam: Optional[torch.Tensor] = None,
         aparam: Optional[torch.Tensor] = None,
+        charge_spin: Optional[torch.Tensor] = None,
         do_atomic_virial: bool = False,
     ) -> dict[str, torch.Tensor]:
         """Forward lower pass with internal DeePMD output names."""
+        if charge_spin is not None:
+            msg = "charge_spin is unsupported"
+            raise ValueError(msg)
         return self.forward_lower_common(
             nlist.shape[1],
             extended_coord,
@@ -1185,6 +1221,7 @@ class MaceModel(BaseModel):
         mapping: Optional[torch.Tensor] = None,
         fparam: Optional[torch.Tensor] = None,
         aparam: Optional[torch.Tensor] = None,
+        charge_spin: Optional[torch.Tensor] = None,
         do_atomic_virial: bool = False,
         **make_fx_kwargs: object,
     ) -> torch.nn.Module:
@@ -1223,6 +1260,7 @@ class MaceModel(BaseModel):
             mapping: Optional[torch.Tensor],
             fparam: Optional[torch.Tensor],
             aparam: Optional[torch.Tensor],
+            charge_spin: Optional[torch.Tensor],
         ) -> dict[str, torch.Tensor]:
             torch._check(extended_coord.shape[1] >= 2)  # noqa: SLF001
             extended_coord = extended_coord.detach().requires_grad_(requires_grad=True)
@@ -1233,6 +1271,7 @@ class MaceModel(BaseModel):
                 mapping=mapping,
                 fparam=fparam,
                 aparam=aparam,
+                charge_spin=charge_spin,
                 do_atomic_virial=do_atomic_virial,
             )
 
@@ -1246,6 +1285,7 @@ class MaceModel(BaseModel):
                 mapping,
                 fparam,
                 aparam,
+                charge_spin,
             )
             _clear_export_guards_once(traced)
             return traced

--- a/deepmd_gnn/nequip.py
+++ b/deepmd_gnn/nequip.py
@@ -349,9 +349,37 @@ class NequipModel(BaseModel):
         return 0
 
     @torch.jit.export
+    def has_default_fparam(self) -> bool:
+        """Return whether default frame parameters are available."""
+        return False
+
+    def get_default_fparam(self) -> torch.Tensor | None:
+        """Get the default frame parameters."""
+        return None
+
+    @torch.jit.export
     def get_dim_aparam(self) -> int:
         """Get the number (dimension) of atomic parameters of this atomic model."""
         return 0
+
+    @torch.jit.export
+    def has_chg_spin_ebd(self) -> bool:
+        """Return whether charge-spin embedding is enabled."""
+        return False
+
+    @torch.jit.export
+    def get_dim_chg_spin(self) -> int:
+        """Get the dimension of charge-spin input."""
+        return 0
+
+    @torch.jit.export
+    def has_default_chg_spin(self) -> bool:
+        """Return whether default charge-spin values are available."""
+        return False
+
+    def get_default_chg_spin(self) -> torch.Tensor | None:
+        """Get the default charge-spin values."""
+        return None
 
     @torch.jit.export
     def get_sel_type(self) -> list[int]:
@@ -468,6 +496,7 @@ class NequipModel(BaseModel):
         mapping: torch.Tensor | None = None,
         fparam: torch.Tensor | None = None,
         aparam: torch.Tensor | None = None,
+        charge_spin: torch.Tensor | None = None,
         do_atomic_virial: bool = False,
         comm_dict: dict[str, torch.Tensor] | None = None,
     ) -> dict[str, torch.Tensor]:
@@ -492,6 +521,9 @@ class NequipModel(BaseModel):
         comm_dict : dict[str, torch.Tensor], optional
             The communication dictionary.
         """
+        if charge_spin is not None:
+            msg = "charge_spin is unsupported"
+            raise ValueError(msg)
         nloc = nlist.shape[1]
         nf, nall = extended_atype.shape
         # recalculate nlist for ghost atoms
@@ -806,9 +838,13 @@ class NequipModel(BaseModel):
         mapping: torch.Tensor | None = None,
         fparam: torch.Tensor | None = None,
         aparam: torch.Tensor | None = None,
+        charge_spin: torch.Tensor | None = None,
         do_atomic_virial: bool = False,
     ) -> dict[str, torch.Tensor]:
         """Forward lower pass with internal DeePMD output names."""
+        if charge_spin is not None:
+            msg = "charge_spin is unsupported"
+            raise ValueError(msg)
         return self.forward_lower_common(
             nlist.shape[1],
             extended_coord,
@@ -829,6 +865,7 @@ class NequipModel(BaseModel):
         mapping: torch.Tensor | None = None,
         fparam: torch.Tensor | None = None,
         aparam: torch.Tensor | None = None,
+        charge_spin: torch.Tensor | None = None,
         do_atomic_virial: bool = False,
         **make_fx_kwargs: object,
     ) -> torch.nn.Module:
@@ -846,6 +883,7 @@ class NequipModel(BaseModel):
             mapping: torch.Tensor | None,
             fparam: torch.Tensor | None,
             aparam: torch.Tensor | None,
+            charge_spin: torch.Tensor | None,
         ) -> dict[str, torch.Tensor]:
             extended_coord = extended_coord.detach().requires_grad_(requires_grad=True)
             return model.forward_common_lower(
@@ -855,6 +893,7 @@ class NequipModel(BaseModel):
                 mapping=mapping,
                 fparam=fparam,
                 aparam=aparam,
+                charge_spin=charge_spin,
                 do_atomic_virial=do_atomic_virial,
             )
 
@@ -867,6 +906,7 @@ class NequipModel(BaseModel):
                 mapping,
                 fparam,
                 aparam,
+                charge_spin,
             )
         finally:
             self._use_exportable_edge_index = False

--- a/deepmd_gnn/nequip.py
+++ b/deepmd_gnn/nequip.py
@@ -176,6 +176,38 @@ def _insert_border_communication_modules(model: GraphModel, num_layers: int) -> 
             model.model_input_fields.append(key)
 
 
+def _make_nequip_network(params: dict[str, Any], ntypes: int) -> GraphModel:
+    nequip_model = model_from_config(
+        {
+            "model_builders": ["EnergyModel"],
+            "avg_num_neighbors": params["sel"],
+            "chemical_symbols": params["type_map"],
+            "num_types": ntypes,
+            "r_max": params["r_max"],
+            "num_layers": params["num_layers"],
+            "l_max": params["l_max"],
+            "num_features": params["num_features"],
+            "nonlinearity_type": params["nonlinearity_type"],
+            "parity": params["parity"],
+            "num_basis": params["num_basis"],
+            "BesselBasis_trainable": params["BesselBasis_trainable"],
+            "PolynomialCutoff_p": params["PolynomialCutoff_p"],
+            "invariant_layers": params["invariant_layers"],
+            "invariant_neurons": params["invariant_neurons"],
+            "use_sc": params["use_sc"],
+            "irreps_edge_sh": params["irreps_edge_sh"],
+            "feature_irreps_hidden": params["feature_irreps_hidden"],
+            "chemical_embedding_irreps_out": params["chemical_embedding_irreps_out"],
+            "conv_to_output_hidden_irreps_out": params[
+                "conv_to_output_hidden_irreps_out"
+            ],
+            "model_dtype": params["precision"],
+        },
+    )
+    _insert_border_communication_modules(nequip_model, params["num_layers"])
+    return nequip_model
+
+
 def _load_observed_type_stat_compat() -> tuple[Any, Any, Any]:
     try:
         stat_mod = importlib.import_module("deepmd.dpmodel.utils.stat")
@@ -321,32 +353,7 @@ class NequipModel(BaseModel):
                 self.mm_types.append(ii)
 
         self.rcut = r_max
-        nequip_model = model_from_config(
-            {
-                "model_builders": ["EnergyModel"],
-                "avg_num_neighbors": sel,
-                "chemical_symbols": type_map,
-                "num_types": self.ntypes,
-                "r_max": r_max,
-                "num_layers": num_layers,
-                "l_max": l_max,
-                "num_features": num_features,
-                "nonlinearity_type": nonlinearity_type,
-                "parity": parity,
-                "num_basis": num_basis,
-                "BesselBasis_trainable": BesselBasis_trainable,
-                "PolynomialCutoff_p": PolynomialCutoff_p,
-                "invariant_layers": invariant_layers,
-                "invariant_neurons": invariant_neurons,
-                "use_sc": use_sc,
-                "irreps_edge_sh": irreps_edge_sh,
-                "feature_irreps_hidden": feature_irreps_hidden,
-                "chemical_embedding_irreps_out": chemical_embedding_irreps_out,
-                "conv_to_output_hidden_irreps_out": conv_to_output_hidden_irreps_out,
-                "model_dtype": precision,
-            },
-        )
-        _insert_border_communication_modules(nequip_model, num_layers)
+        nequip_model = _make_nequip_network(self.params, self.ntypes)
         self.model = script(nequip_model.to(env.DEVICE))
         self.register_buffer(
             "e0",
@@ -1016,6 +1023,10 @@ class NequipModel(BaseModel):
             make_fx_kwargs["tracing_mode"] = "real"
             make_fx_kwargs.pop("_allow_non_fake_inputs", None)
         model = self
+        scripted_model = self.model
+        raw_model = _make_nequip_network(self.params, self.ntypes).to(self.e0.device)
+        raw_model.load_state_dict(scripted_model.state_dict())
+        raw_model.train(scripted_model.training)
 
         def fn(
             extended_coord: torch.Tensor,
@@ -1040,6 +1051,7 @@ class NequipModel(BaseModel):
             )
 
         self._use_exportable_edge_index = True
+        self.model = raw_model
         try:
             return make_fx(fn, **make_fx_kwargs)(
                 extended_coord,
@@ -1051,6 +1063,7 @@ class NequipModel(BaseModel):
                 charge_spin,
             )
         finally:
+            self.model = scripted_model
             self._use_exportable_edge_index = False
 
     def serialize(self) -> dict:

--- a/deepmd_gnn/nequip.py
+++ b/deepmd_gnn/nequip.py
@@ -498,9 +498,9 @@ class NequipModel(BaseModel):
         mapping: torch.Tensor | None = None,
         fparam: torch.Tensor | None = None,
         aparam: torch.Tensor | None = None,
-        charge_spin: torch.Tensor | None = None,
         do_atomic_virial: bool = False,
         comm_dict: dict[str, torch.Tensor] | None = None,
+        charge_spin: torch.Tensor | None = None,
     ) -> dict[str, torch.Tensor]:
         """Forward lower pass of the model.
 

--- a/deepmd_gnn/nequip.py
+++ b/deepmd_gnn/nequip.py
@@ -54,6 +54,15 @@ from deepmd_gnn.autograd import derive_atomic_virial_from_displacement
 from deepmd_gnn.edge import dense_edge_index
 
 
+def _pad_nlist_for_export(nlist: torch.Tensor) -> torch.Tensor:
+    pad = -torch.ones(
+        (*nlist.shape[:2], 1),
+        dtype=nlist.dtype,
+        device=nlist.device,
+    )
+    return torch.cat([nlist, pad], dim=-1)
+
+
 def _load_observed_type_stat_compat() -> tuple[Any, Any, Any]:
     try:
         stat_mod = importlib.import_module("deepmd.dpmodel.utils.stat")
@@ -884,6 +893,7 @@ class NequipModel(BaseModel):
             charge_spin: torch.Tensor | None,
         ) -> dict[str, torch.Tensor]:
             extended_coord = extended_coord.detach().requires_grad_(requires_grad=True)
+            nlist = _pad_nlist_for_export(nlist)
             return model.forward_common_lower(
                 extended_coord,
                 extended_atype,

--- a/deepmd_gnn/nequip.py
+++ b/deepmd_gnn/nequip.py
@@ -1058,7 +1058,7 @@ class NequipModel(BaseModel):
         return {
             "@class": "Model",
             "@version": 1,
-            "type": "mace",
+            "type": "nequip",
             **self.params,
             "@variables": {
                 **{
@@ -1072,7 +1072,7 @@ class NequipModel(BaseModel):
     def deserialize(cls, data: dict) -> "NequipModel":
         """Deserialize the model."""
         data = data.copy()
-        if not (data.pop("@class") == "Model" and data.pop("type") == "mace"):
+        if not (data.pop("@class") == "Model" and data.pop("type") == "nequip"):
             msg = "data is not a serialized NequipModel"
             raise ValueError(msg)
         check_version_compatibility(data.pop("@version"), 1, 1)

--- a/deepmd_gnn/nequip.py
+++ b/deepmd_gnn/nequip.py
@@ -425,6 +425,7 @@ class NequipModel(BaseModel):
         box: torch.Tensor | None = None,
         fparam: torch.Tensor | None = None,
         aparam: torch.Tensor | None = None,
+        charge_spin: torch.Tensor | None = None,
         do_atomic_virial: bool = False,
     ) -> dict[str, torch.Tensor]:
         """Forward pass of the model.
@@ -444,6 +445,7 @@ class NequipModel(BaseModel):
         do_atomic_virial : bool, optional
             Whether to compute atomic virial.
         """
+        _ = charge_spin
         nloc = atype.shape[1]
         extended_coord, extended_atype, mapping, nlist = (
             extend_input_and_build_neighbor_list(
@@ -521,9 +523,7 @@ class NequipModel(BaseModel):
         comm_dict : dict[str, torch.Tensor], optional
             The communication dictionary.
         """
-        if charge_spin is not None:
-            msg = "charge_spin is unsupported"
-            raise ValueError(msg)
+        _ = charge_spin
         nloc = nlist.shape[1]
         nf, nall = extended_atype.shape
         # recalculate nlist for ghost atoms
@@ -842,9 +842,7 @@ class NequipModel(BaseModel):
         do_atomic_virial: bool = False,
     ) -> dict[str, torch.Tensor]:
         """Forward lower pass with internal DeePMD output names."""
-        if charge_spin is not None:
-            msg = "charge_spin is unsupported"
-            raise ValueError(msg)
+        _ = charge_spin
         return self.forward_lower_common(
             nlist.shape[1],
             extended_coord,

--- a/deepmd_gnn/nequip.py
+++ b/deepmd_gnn/nequip.py
@@ -46,8 +46,12 @@ from e3nn.util.jit import (
     script,
 )
 from nequip.model import model_from_config
+from torch.fx.experimental.proxy_tensor import (
+    make_fx,
+)
 
 from deepmd_gnn.autograd import derive_atomic_virial_from_displacement
+from deepmd_gnn.edge import dense_edge_index
 
 
 def _load_observed_type_stat_compat() -> tuple[Any, Any, Any]:
@@ -320,6 +324,10 @@ class NequipModel(BaseModel):
             ],
         )
 
+    def atomic_output_def(self) -> FittingOutputDef:
+        """Get the atomic output def used by the exportable backend."""
+        return self.fitting_output_def()
+
     @torch.jit.export
     def get_rcut(self) -> float:
         """Get the cut-off radius."""
@@ -571,11 +579,23 @@ class NequipModel(BaseModel):
 
         extended_coord_ff = extended_coord.view(nf * nall, 3)
         extended_atype_ff = extended_atype.view(nf * nall)
-        edge_index = torch.ops.deepmd_gnn.edge_index(
-            nlist,
-            extended_atype,
-            torch.tensor(self.mm_types, dtype=torch.int64, device="cpu"),
-        )
+        edge_mask = torch.jit.annotate(torch.Tensor | None, None)
+        if torch.jit.is_scripting() or not getattr(
+            self,
+            "_use_exportable_edge_index",
+            False,
+        ):
+            edge_index = torch.ops.deepmd_gnn.edge_index(
+                nlist,
+                extended_atype,
+                torch.tensor(self.mm_types, dtype=torch.int64, device="cpu"),
+            )
+        else:
+            edge_index, edge_mask = dense_edge_index(
+                nlist,
+                extended_atype,
+                self.mm_types,
+            )
         edge_index = edge_index.T
         # Nequip and MACE have different defination for edge_index
         edge_index = edge_index[[1, 0]]
@@ -608,6 +628,11 @@ class NequipModel(BaseModel):
             shifts = shifts_atoms[edge_index[1]] - shifts_atoms[edge_index[0]]
             edge_index = mapping_ff[edge_index]
             input_dict["edge_index"] = edge_index
+        if edge_mask is not None:
+            edge_mask = edge_mask.to(device=shifts.device)
+            far_shifts = torch.zeros_like(shifts)
+            far_shifts[:, 0] = self.rcut * 10.0 + 10.0
+            shifts = torch.where(edge_mask.unsqueeze(-1), shifts, far_shifts)
 
         batch = (
             torch.arange(
@@ -664,6 +689,19 @@ class NequipModel(BaseModel):
             input_dict["edge_cell_shift"] = edge_cell_shift
         else:
             input_dict["pos"] = extended_coord_ff
+            if edge_mask is not None:
+                input_dict["batch"] = batch
+                input_dict["ptr"] = ptr
+                input_dict["cell"] = (
+                    torch.eye(
+                        3,
+                        dtype=extended_coord_ff.dtype,
+                        device=extended_coord_ff.device,
+                    )
+                    .unsqueeze(0)
+                    .expand(nf, 3, 3)
+                )
+                input_dict["edge_cell_shift"] = shifts
 
         ret = self.model.forward(
             input_dict,
@@ -759,6 +797,79 @@ class NequipModel(BaseModel):
             "energy": atom_energy.view(nf, nloc, 1).to(extended_coord_.dtype),
             "energy_derv_c": atomic_virial.to(extended_coord_.dtype),
         }
+
+    def forward_common_lower(
+        self,
+        extended_coord: torch.Tensor,
+        extended_atype: torch.Tensor,
+        nlist: torch.Tensor,
+        mapping: torch.Tensor | None = None,
+        fparam: torch.Tensor | None = None,
+        aparam: torch.Tensor | None = None,
+        do_atomic_virial: bool = False,
+    ) -> dict[str, torch.Tensor]:
+        """Forward lower pass with internal DeePMD output names."""
+        return self.forward_lower_common(
+            nlist.shape[1],
+            extended_coord,
+            extended_atype,
+            nlist,
+            mapping=mapping,
+            fparam=fparam,
+            aparam=aparam,
+            do_atomic_virial=do_atomic_virial,
+            comm_dict=None,
+        )
+
+    def forward_common_lower_exportable(
+        self,
+        extended_coord: torch.Tensor,
+        extended_atype: torch.Tensor,
+        nlist: torch.Tensor,
+        mapping: torch.Tensor | None = None,
+        fparam: torch.Tensor | None = None,
+        aparam: torch.Tensor | None = None,
+        do_atomic_virial: bool = False,
+        **make_fx_kwargs: object,
+    ) -> torch.nn.Module:
+        """Trace ``forward_common_lower`` for ``torch.export`` serialization."""
+        make_fx_kwargs = make_fx_kwargs.copy()
+        if make_fx_kwargs.get("tracing_mode") == "symbolic":
+            make_fx_kwargs["tracing_mode"] = "real"
+            make_fx_kwargs.pop("_allow_non_fake_inputs", None)
+        model = self
+
+        def fn(
+            extended_coord: torch.Tensor,
+            extended_atype: torch.Tensor,
+            nlist: torch.Tensor,
+            mapping: torch.Tensor | None,
+            fparam: torch.Tensor | None,
+            aparam: torch.Tensor | None,
+        ) -> dict[str, torch.Tensor]:
+            extended_coord = extended_coord.detach().requires_grad_(requires_grad=True)
+            return model.forward_common_lower(
+                extended_coord,
+                extended_atype,
+                nlist,
+                mapping=mapping,
+                fparam=fparam,
+                aparam=aparam,
+                do_atomic_virial=do_atomic_virial,
+            )
+
+        self._use_exportable_edge_index = True
+        try:
+            return make_fx(fn, **make_fx_kwargs)(
+                extended_coord,
+                extended_atype,
+                nlist,
+                mapping,
+                fparam,
+                aparam,
+            )
+        finally:
+            self._use_exportable_edge_index = False
 
     def serialize(self) -> dict:
         """Serialize the model."""

--- a/deepmd_gnn/pt.py
+++ b/deepmd_gnn/pt.py
@@ -1,0 +1,33 @@
+"""PyTorch backend plugin registration."""
+
+import sys
+
+
+def load() -> None:
+    """Entry point placeholder; importing this module registers plugins."""
+
+
+def _is_partially_initialized(module_name: str, attr_name: str) -> bool:
+    module = sys.modules.get(module_name)
+    return module is not None and not hasattr(module, attr_name)
+
+
+def _register() -> None:
+    if _is_partially_initialized(
+        "deepmd_gnn.mace",
+        "MaceModel",
+    ) or _is_partially_initialized("deepmd_gnn.nequip", "NequipModel"):
+        return
+
+    from deepmd.pt.model.model.model import (  # noqa: PLC0415
+        BaseModel as PyTorchBaseModel,
+    )
+
+    from deepmd_gnn.mace import MaceModel  # noqa: PLC0415
+    from deepmd_gnn.nequip import NequipModel  # noqa: PLC0415
+
+    PyTorchBaseModel.register("mace")(MaceModel)
+    PyTorchBaseModel.register("nequip")(NequipModel)
+
+
+_register()

--- a/deepmd_gnn/pt_expt.py
+++ b/deepmd_gnn/pt_expt.py
@@ -16,7 +16,7 @@ def _register() -> None:
     if _is_partially_initialized(
         "deepmd_gnn.mace",
         "MaceModel",
-    ) or _is_partially_initialized("deepmd_gnn.nequip", "NequipModel"):
+    ):
         return
 
     from deepmd.pt_expt.model.model import (  # noqa: PLC0415
@@ -24,10 +24,10 @@ def _register() -> None:
     )
 
     from deepmd_gnn.mace import MaceModel  # noqa: PLC0415
-    from deepmd_gnn.nequip import NequipModel  # noqa: PLC0415
 
+    # NeQuIP 0.6/e3nn specializes atom and edge counts during torch.export.
+    # Keep pt_expt registration limited to models with dynamic-shape export.
     ExportableBaseModel.register("mace")(MaceModel)
-    ExportableBaseModel.register("nequip")(NequipModel)
 
 
 _register()

--- a/deepmd_gnn/pt_expt.py
+++ b/deepmd_gnn/pt_expt.py
@@ -1,0 +1,33 @@
+"""PyTorch exportable backend plugin registration."""
+
+import sys
+
+
+def load() -> None:
+    """Entry point placeholder; importing this module registers plugins."""
+
+
+def _is_partially_initialized(module_name: str, attr_name: str) -> bool:
+    module = sys.modules.get(module_name)
+    return module is not None and not hasattr(module, attr_name)
+
+
+def _register() -> None:
+    if _is_partially_initialized(
+        "deepmd_gnn.mace",
+        "MaceModel",
+    ) or _is_partially_initialized("deepmd_gnn.nequip", "NequipModel"):
+        return
+
+    from deepmd.pt_expt.model.model import (  # noqa: PLC0415
+        BaseModel as ExportableBaseModel,
+    )
+
+    from deepmd_gnn.mace import MaceModel  # noqa: PLC0415
+    from deepmd_gnn.nequip import NequipModel  # noqa: PLC0415
+
+    ExportableBaseModel.register("mace")(MaceModel)
+    ExportableBaseModel.register("nequip")(NequipModel)
+
+
+_register()

--- a/noxfile.py
+++ b/noxfile.py
@@ -18,7 +18,11 @@ def install_editable(session: nox.Session) -> None:
         silent=True,
     ).strip()
     session.log(f"{cmake_prefix_path=}")
-    session.install("-e.[test]", env={"CMAKE_PREFIX_PATH": cmake_prefix_path})
+    session.install(
+        "-e.[test]",
+        "deepmd-kit[torch]>=3.2.0b0",
+        env={"CMAKE_PREFIX_PATH": cmake_prefix_path},
+    )
 
 
 @nox.session

--- a/noxfile.py
+++ b/noxfile.py
@@ -7,26 +7,35 @@ import nox
 nox.options.sessions = ["tests"]
 
 PYTORCH_CPU_INDEX_URL = "https://download.pytorch.org/whl/cpu"
-# MACE pins e3nn 0.4.4, while deepmd-kit 3.2 declares e3nn>=0.5.9.
+UV_OVERRIDES = "requirements-overrides.txt"
 MACE_E3NN = "e3nn==0.4.4"
-PROJECT_RUNTIME_DEPS = [
+RUNTIME_DEPS = [
     "mace-torch>=0.3.5",
     "nequip",
     MACE_E3NN,
     "dargs",
 ]
-PROJECT_TEST_DEPS = [
+TEST_DEPS = [
     "pytest",
     "pytest-cov",
     "dargs>=0.4.8",
 ]
 
 
-def install_project_deps(session: nox.Session) -> None:
-    """Install project dependencies without re-solving deepmd-kit."""
+def install_deps(
+    session: nox.Session,
+    deepmd_requirement: str,
+    *extra_requirements: str,
+) -> None:
+    """Install all dependencies with MACE's e3nn override in one resolution."""
     session.install(
-        *PROJECT_RUNTIME_DEPS,
-        *PROJECT_TEST_DEPS,
+        "numpy",
+        deepmd_requirement,
+        *RUNTIME_DEPS,
+        *TEST_DEPS,
+        *extra_requirements,
+        "--overrides",
+        UV_OVERRIDES,
         "--extra-index-url",
         PYTORCH_CPU_INDEX_URL,
     )
@@ -51,13 +60,7 @@ def install_editable(session: nox.Session) -> None:
 @nox.session
 def tests(session: nox.Session) -> None:
     """Run test suite with pytest."""
-    session.install(
-        "numpy",
-        "deepmd-kit[torch]>=3.2.0b0",
-        "--extra-index-url",
-        PYTORCH_CPU_INDEX_URL,
-    )
-    install_project_deps(session)
+    install_deps(session, "deepmd-kit[torch]>=3.2.0b0")
     install_editable(session)
     session.run(
         "pytest",
@@ -74,15 +77,12 @@ def tests(session: nox.Session) -> None:
 @nox.session
 def lammps(session: nox.Session) -> None:
     """Run LAMMPS integration tests."""
-    session.install(
-        "numpy",
+    install_deps(
+        session,
         "deepmd-kit[torch,lmp,cpu]>=3.2.0b0",
         "mpi4py",
         "mpich",
-        "--extra-index-url",
-        PYTORCH_CPU_INDEX_URL,
     )
-    install_project_deps(session)
     install_editable(session)
     session.run(
         "pytest",

--- a/noxfile.py
+++ b/noxfile.py
@@ -9,7 +9,7 @@ import nox
 nox.options.sessions = ["tests"]
 
 UV_OVERRIDES = "requirements-overrides.txt"
-UV_TORCH_BACKEND = os.environ.get("UV_TORCH_BACKEND", "auto")
+UV_TORCH_BACKEND = os.environ.get("UV_TORCH_BACKEND", "cpu")
 
 
 def install(

--- a/noxfile.py
+++ b/noxfile.py
@@ -26,7 +26,7 @@ def tests(session: nox.Session) -> None:
     """Run test suite with pytest."""
     session.install(
         "numpy",
-        "deepmd-kit[torch]>=3.0.0b2",
+        "deepmd-kit[torch]>=3.2.0b0",
         "--extra-index-url",
         PYTORCH_CPU_INDEX_URL,
     )
@@ -48,7 +48,7 @@ def lammps(session: nox.Session) -> None:
     """Run LAMMPS integration tests."""
     session.install(
         "numpy",
-        "deepmd-kit[torch,lmp,cpu]>=3.0.0",
+        "deepmd-kit[torch,lmp,cpu]>=3.2.0b0",
         "mpi4py",
         "mpich",
         "--extra-index-url",

--- a/noxfile.py
+++ b/noxfile.py
@@ -6,23 +6,10 @@ import nox
 
 nox.options.sessions = ["tests"]
 
-PYTORCH_CPU_INDEX_URL = "https://download.pytorch.org/whl/cpu"
 UV_OVERRIDES = "requirements-overrides.txt"
-MACE_E3NN = "e3nn==0.4.4"
-RUNTIME_DEPS = [
-    "mace-torch>=0.3.5",
-    "nequip",
-    MACE_E3NN,
-    "dargs",
-]
-TEST_DEPS = [
-    "pytest",
-    "pytest-cov",
-    "dargs>=0.4.8",
-]
 
 
-def install_deps(
+def install(
     session: nox.Session,
     deepmd_requirement: str,
     *extra_requirements: str,
@@ -31,37 +18,19 @@ def install_deps(
     session.install(
         "numpy",
         deepmd_requirement,
-        *RUNTIME_DEPS,
-        *TEST_DEPS,
         *extra_requirements,
+        "-e.[test]",
         "--overrides",
         UV_OVERRIDES,
-        "--extra-index-url",
-        PYTORCH_CPU_INDEX_URL,
-    )
-
-
-def install_editable(session: nox.Session) -> None:
-    """Install this package against the PyTorch in the nox environment."""
-    cmake_prefix_path = session.run(
-        "python",
-        "-c",
-        "import torch;print(torch.utils.cmake_prefix_path)",
-        silent=True,
-    ).strip()
-    session.log(f"{cmake_prefix_path=}")
-    session.install(
-        "--no-deps",
-        "-e.",
-        env={"CMAKE_PREFIX_PATH": cmake_prefix_path},
+        "--torch-backend",
+        "auto",
     )
 
 
 @nox.session
 def tests(session: nox.Session) -> None:
     """Run test suite with pytest."""
-    install_deps(session, "deepmd-kit[torch]>=3.2.0b0")
-    install_editable(session)
+    install(session, "deepmd-kit[torch]>=3.2.0b0")
     session.run(
         "pytest",
         "--cov",
@@ -77,13 +46,12 @@ def tests(session: nox.Session) -> None:
 @nox.session
 def lammps(session: nox.Session) -> None:
     """Run LAMMPS integration tests."""
-    install_deps(
+    install(
         session,
         "deepmd-kit[torch,lmp,cpu]>=3.2.0b0",
         "mpi4py",
         "mpich",
     )
-    install_editable(session)
     session.run(
         "pytest",
         "-m",

--- a/noxfile.py
+++ b/noxfile.py
@@ -7,6 +7,29 @@ import nox
 nox.options.sessions = ["tests"]
 
 PYTORCH_CPU_INDEX_URL = "https://download.pytorch.org/whl/cpu"
+# MACE pins e3nn 0.4.4, while deepmd-kit 3.2 declares e3nn>=0.5.9.
+MACE_E3NN = "e3nn==0.4.4"
+PROJECT_RUNTIME_DEPS = [
+    "mace-torch>=0.3.5",
+    "nequip",
+    MACE_E3NN,
+    "dargs",
+]
+PROJECT_TEST_DEPS = [
+    "pytest",
+    "pytest-cov",
+    "dargs>=0.4.8",
+]
+
+
+def install_project_deps(session: nox.Session) -> None:
+    """Install project dependencies without re-solving deepmd-kit."""
+    session.install(
+        *PROJECT_RUNTIME_DEPS,
+        *PROJECT_TEST_DEPS,
+        "--extra-index-url",
+        PYTORCH_CPU_INDEX_URL,
+    )
 
 
 def install_editable(session: nox.Session) -> None:
@@ -19,8 +42,8 @@ def install_editable(session: nox.Session) -> None:
     ).strip()
     session.log(f"{cmake_prefix_path=}")
     session.install(
-        "-e.[test]",
-        "deepmd-kit[torch]>=3.2.0b0",
+        "--no-deps",
+        "-e.",
         env={"CMAKE_PREFIX_PATH": cmake_prefix_path},
     )
 
@@ -34,6 +57,7 @@ def tests(session: nox.Session) -> None:
         "--extra-index-url",
         PYTORCH_CPU_INDEX_URL,
     )
+    install_project_deps(session)
     install_editable(session)
     session.run(
         "pytest",
@@ -58,6 +82,7 @@ def lammps(session: nox.Session) -> None:
         "--extra-index-url",
         PYTORCH_CPU_INDEX_URL,
     )
+    install_project_deps(session)
     install_editable(session)
     session.run(
         "pytest",

--- a/op/edge_index.cc
+++ b/op/edge_index.cc
@@ -11,6 +11,7 @@
 #include <algorithm>
 #include <cstdint>
 #include <stdexcept>
+#include <tuple>
 #include <vector>
 
 #ifdef DEEPMD_GNN_WITH_CUDA
@@ -66,6 +67,42 @@ ts::Tensor to_cpu_contiguous(const ts::Tensor& tensor) {
   return to_device_contiguous(tensor, ts::Device(th::DeviceType::CPU));
 }
 
+bool type_in_mm(const int64_t atom_type, const int64_t* mm, const int64_t nmm) {
+  for (int64_t mm_idx = 0; mm_idx < nmm; mm_idx++) {
+    if (atom_type == mm[mm_idx]) {
+      return true;
+    }
+  }
+  return false;
+}
+
+template <typename Fn>
+void visit_edges(const EdgeIndexShape& shape,
+                 const int64_t* nlist,
+                 const int64_t* atype,
+                 const int64_t* mm,
+                 const int64_t nmm,
+                 Fn&& fn) {
+  for (int64_t ff = 0; ff < shape.nf; ff++) {
+    for (int64_t ii = 0; ii < shape.nloc; ii++) {
+      for (int64_t jj = 0; jj < shape.nnei; jj++) {
+        const int64_t idx = ff * shape.nloc * shape.nnei + ii * shape.nnei + jj;
+        const int64_t kk = nlist[idx];
+        const int64_t safe_kk = std::max<int64_t>(kk, 0);
+        const int64_t global_kk = ff * shape.nall + safe_kk;
+        const int64_t global_ii = ff * shape.nall + ii;
+        bool valid = kk >= 0;
+        if (valid && nmm > 0) {
+          const bool in_mm1 = type_in_mm(atype[global_ii], mm, nmm);
+          const bool in_mm2 = type_in_mm(atype[global_kk], mm, nmm);
+          valid = !(in_mm1 && in_mm2);
+        }
+        fn(idx, global_kk, global_ii, valid);
+      }
+    }
+  }
+}
+
 ts::Tensor edge_index_cpu_kernel(const ts::Tensor& nlist_tensor,
                                  const ts::Tensor& atype_tensor,
                                  const ts::Tensor& mm_tensor) {
@@ -81,39 +118,15 @@ ts::Tensor edge_index_cpu_kernel(const ts::Tensor& nlist_tensor,
 
   std::vector<int64_t> edge_index;
   edge_index.reserve(shape.nf * shape.nloc * shape.nnei * 2);
-
-  for (int64_t ff = 0; ff < shape.nf; ff++) {
-    for (int64_t ii = 0; ii < shape.nloc; ii++) {
-      for (int64_t jj = 0; jj < shape.nnei; jj++) {
-        const int64_t idx = ff * shape.nloc * shape.nnei + ii * shape.nnei + jj;
-        const int64_t kk = nlist[idx];
-        if (kk < 0) {
-          continue;
-        }
-        const int64_t global_kk = ff * shape.nall + kk;
-        const int64_t global_ii = ff * shape.nall + ii;
-        bool in_mm1 = false;
-        for (int64_t mm_idx = 0; mm_idx < nmm; mm_idx++) {
-          if (atype[global_ii] == mm[mm_idx]) {
-            in_mm1 = true;
-            break;
-          }
-        }
-        bool in_mm2 = false;
-        for (int64_t mm_idx = 0; mm_idx < nmm; mm_idx++) {
-          if (atype[global_kk] == mm[mm_idx]) {
-            in_mm2 = true;
-            break;
-          }
-        }
-        if (in_mm1 && in_mm2) {
-          continue;
-        }
-        edge_index.push_back(global_kk);
-        edge_index.push_back(global_ii);
-      }
-    }
-  }
+  visit_edges(shape, nlist, atype, mm, nmm,
+              [&edge_index](const int64_t /*idx*/, const int64_t global_kk,
+                            const int64_t global_ii, const bool valid) {
+                if (!valid) {
+                  return;
+                }
+                edge_index.push_back(global_kk);
+                edge_index.push_back(global_ii);
+              });
 
   const int64_t edge_size = static_cast<int64_t>(edge_index.size() / 2);
   ts::Tensor edge_index_tensor =
@@ -159,15 +172,62 @@ ts::Tensor edge_index_kernel(const ts::Tensor& nlist_tensor,
 #endif
   return edge_index_cpu_kernel(nlist_tensor, atype_tensor, mm_tensor);
 }
+
+std::tuple<ts::Tensor, ts::Tensor> dense_edge_index_kernel(
+    const ts::Tensor& nlist_tensor,
+    const ts::Tensor& atype_tensor,
+    const ts::Tensor& mm_tensor) {
+  ts::Tensor nlist_tensor_ = to_cpu_contiguous(nlist_tensor);
+  ts::Tensor atype_tensor_ = to_cpu_contiguous(atype_tensor);
+  ts::Tensor mm_tensor_ = to_cpu_contiguous(mm_tensor);
+
+  const EdgeIndexShape shape = validate_shape(nlist_tensor_, atype_tensor_);
+  const int64_t nmm = mm_tensor_.size(0);
+  const int64_t* nlist = nlist_tensor_.const_data_ptr<int64_t>();
+  const int64_t* atype = atype_tensor_.const_data_ptr<int64_t>();
+  const int64_t* mm = mm_tensor_.const_data_ptr<int64_t>();
+  const int64_t dense_edge_size = shape.nf * shape.nloc * shape.nnei;
+
+  ts::Tensor edge_index_tensor =
+      ts::empty({dense_edge_size, 2}, th::ScalarType::Long, th::Layout::Strided,
+                ts::Device(th::DeviceType::CPU));
+  ts::Tensor edge_mask_tensor =
+      ts::empty({dense_edge_size}, th::ScalarType::Bool, th::Layout::Strided,
+                ts::Device(th::DeviceType::CPU));
+  int64_t* edge_index = edge_index_tensor.mutable_data_ptr<int64_t>();
+  bool* edge_mask = edge_mask_tensor.mutable_data_ptr<bool>();
+
+  visit_edges(
+      shape, nlist, atype, mm, nmm,
+      [edge_index, edge_mask](const int64_t idx, const int64_t global_kk,
+                              const int64_t global_ii, const bool valid) {
+        edge_index[2 * idx] = global_kk;
+        edge_index[2 * idx + 1] = global_ii;
+        edge_mask[idx] = valid;
+      });
+
+  return std::make_tuple(ts::to(edge_index_tensor, nlist_tensor.device()),
+                         ts::to(edge_mask_tensor, nlist_tensor.device()));
+}
 }  // namespace
 
 STABLE_TORCH_LIBRARY(deepmd_gnn, m) {
   m.def("edge_index(Tensor nlist, Tensor atype, Tensor mm) -> Tensor");
+  m.def(
+      "dense_edge_index(Tensor nlist, Tensor atype, Tensor mm) -> (Tensor, "
+      "Tensor)");
+}
+
+STABLE_TORCH_LIBRARY_IMPL(deepmd_gnn, CompositeExplicitAutograd, m) {
   m.impl("edge_index", TORCH_BOX(edge_index_kernel));
+  m.impl("dense_edge_index", TORCH_BOX(dense_edge_index_kernel));
 }
 
 // Compatibility with old models frozen by deepmd_mace package.
 STABLE_TORCH_LIBRARY(deepmd_mace, m) {
   m.def("mace_edge_index(Tensor nlist, Tensor atype, Tensor mm) -> Tensor");
+}
+
+STABLE_TORCH_LIBRARY_IMPL(deepmd_mace, CompositeExplicitAutograd, m) {
   m.impl("mace_edge_index", TORCH_BOX(edge_index_kernel));
 }

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -46,7 +46,6 @@ nequip = "deepmd_gnn.pt:load"
 
 [project.entry-points."deepmd.pt_expt"]
 mace = "deepmd_gnn.pt_expt:load"
-nequip = "deepmd_gnn.pt_expt:load"
 
 [project.urls]
 repository = "https://gitlab.com/RutgersLBSR/deepmd-gnn"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -29,7 +29,7 @@ dependencies = [
     "deepmd-kit[torch]>=3.0.0",
     "mace-torch>=0.3.5",
     "nequip",
-    "e3nn==0.4.4",
+    "e3nn",
     "dargs",
 ]
 requires-python = ">=3.10"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -28,7 +28,7 @@ dependencies = [
     "torch>=2.10",
     "deepmd-kit[torch]>=3.0.0",
     "mace-torch>=0.3.5",
-    "nequip",
+    "nequip<0.7",
     "e3nn",
     "dargs",
 ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -29,7 +29,7 @@ dependencies = [
     "deepmd-kit[torch]>=3.0.0",
     "mace-torch>=0.3.5",
     "nequip",
-    "e3nn",
+    "e3nn==0.4.4",
     "dargs",
 ]
 requires-python = ">=3.10"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -41,8 +41,12 @@ keywords = [
 deepmd-gnn = "deepmd_gnn.cli:main"
 
 [project.entry-points."deepmd.pt"]
-mace = "deepmd_gnn.mace:MaceModel"
-nequip = "deepmd_gnn.nequip:NequipModel"
+mace = "deepmd_gnn.pt:load"
+nequip = "deepmd_gnn.pt:load"
+
+[project.entry-points."deepmd.pt_expt"]
+mace = "deepmd_gnn.pt_expt:load"
+nequip = "deepmd_gnn.pt_expt:load"
 
 [project.urls]
 repository = "https://gitlab.com/RutgersLBSR/deepmd-gnn"

--- a/requirements-overrides.txt
+++ b/requirements-overrides.txt
@@ -1,0 +1,2 @@
+# MACE pins e3nn 0.4.4; use uv overrides to keep deepmd-kit>=3.2 with it.
+e3nn==0.4.4

--- a/tests/_pt_expt.py
+++ b/tests/_pt_expt.py
@@ -5,8 +5,16 @@ from __future__ import annotations
 import os
 from typing import TYPE_CHECKING
 
+import pytest
+
 if TYPE_CHECKING:
     from pathlib import Path
+
+
+def skip_cuda_pt_expt_aoti_if_requested() -> None:
+    """Skip pt_expt AOTI packaging in CUDA CI when the runner cannot compile it."""
+    if os.environ.get("DEEPMD_GNN_SKIP_CUDA_PT_EXPT_AOTI") == "1":
+        pytest.skip("pt_expt AOTI packaging is covered by the CPU workflow")
 
 
 def register_pt_expt_plugin_for_cli(work_dir: Path) -> None:

--- a/tests/_pt_expt.py
+++ b/tests/_pt_expt.py
@@ -2,18 +2,39 @@
 
 from __future__ import annotations
 
+import os
 from typing import TYPE_CHECKING
-
-from packaging.version import Version
 
 if TYPE_CHECKING:
     from pathlib import Path
-
-DEEPMD_KIT_PT2_MIN_VERSION = Version("3.2.0b0")
 
 
 def register_pt_expt_plugin_for_cli(work_dir: Path) -> None:
     """Load deepmd-gnn's pt_expt entry point before the deepmd CLI runs."""
     (work_dir / "sitecustomize.py").write_text(
-        "# Temporary workaround for deepmodeling/deepmd-kit#5559.\ntry:\n    import deepmd_gnn.pt_expt  # noqa: F401\nexcept Exception as exc:\n    raise SystemExit(\n        f'Failed to register deepmd-gnn pt_expt plugin: {exc}'\n    ) from exc\n",
+        """# Temporary workaround for deepmodeling/deepmd-kit#5559.
+try:
+    import deepmd_gnn.argcheck  # noqa: F401
+    import deepmd_gnn.pt_expt  # noqa: F401
+except Exception as exc:
+    raise SystemExit(
+        f'Failed to register deepmd-gnn pt_expt plugin: {exc}'
+    ) from exc
+""",
     )
+
+
+def pt_expt_cli_env(
+    work_dir: Path,
+    env: dict[str, str] | None = None,
+) -> dict[str, str]:
+    """Return an environment that imports the temporary CLI registration hook."""
+    register_pt_expt_plugin_for_cli(work_dir)
+    if env is None:
+        env = os.environ.copy()
+    pythonpath = env.get("PYTHONPATH")
+    entries = [str(work_dir)]
+    if pythonpath:
+        entries.append(pythonpath)
+    env["PYTHONPATH"] = os.pathsep.join(entries)
+    return env

--- a/tests/_pt_expt.py
+++ b/tests/_pt_expt.py
@@ -2,34 +2,14 @@
 
 from __future__ import annotations
 
-from importlib.metadata import PackageNotFoundError
-from importlib.metadata import version as package_version
 from typing import TYPE_CHECKING
 
-import pytest
-from packaging.version import InvalidVersion, Version
+from packaging.version import Version
 
 if TYPE_CHECKING:
     from pathlib import Path
 
 DEEPMD_KIT_PT2_MIN_VERSION = Version("3.2.0b0")
-
-
-def require_deepmd_kit_pt2_support() -> None:
-    """Skip when deepmd-kit is too old for the pt2 path."""
-    try:
-        installed = Version(package_version("deepmd-kit"))
-    except PackageNotFoundError:
-        pytest.skip("Cannot determine deepmd-kit version")
-    except InvalidVersion as exc:
-        pytest.skip(f"Cannot parse deepmd-kit version: {exc}")
-
-    if installed < DEEPMD_KIT_PT2_MIN_VERSION:
-        pytest.skip(
-            "deepmd-kit >= "
-            f"{DEEPMD_KIT_PT2_MIN_VERSION} is required for pt2 tests; "
-            f"found {installed}",
-        )
 
 
 def register_pt_expt_plugin_for_cli(work_dir: Path) -> None:

--- a/tests/_pt_expt.py
+++ b/tests/_pt_expt.py
@@ -1,0 +1,39 @@
+"""Helpers for pt_expt integration tests."""
+
+from __future__ import annotations
+
+from importlib.metadata import PackageNotFoundError
+from importlib.metadata import version as package_version
+from typing import TYPE_CHECKING
+
+import pytest
+from packaging.version import InvalidVersion, Version
+
+if TYPE_CHECKING:
+    from pathlib import Path
+
+DEEPMD_KIT_PT2_MIN_VERSION = Version("3.2.0b0")
+
+
+def require_deepmd_kit_pt2_support() -> None:
+    """Skip when deepmd-kit is too old for the pt2 path."""
+    try:
+        installed = Version(package_version("deepmd-kit"))
+    except PackageNotFoundError:
+        pytest.skip("Cannot determine deepmd-kit version")
+    except InvalidVersion as exc:
+        pytest.skip(f"Cannot parse deepmd-kit version: {exc}")
+
+    if installed < DEEPMD_KIT_PT2_MIN_VERSION:
+        pytest.skip(
+            "deepmd-kit >= "
+            f"{DEEPMD_KIT_PT2_MIN_VERSION} is required for pt2 tests; "
+            f"found {installed}",
+        )
+
+
+def register_pt_expt_plugin_for_cli(work_dir: Path) -> None:
+    """Load deepmd-gnn's pt_expt entry point before the deepmd CLI runs."""
+    (work_dir / "sitecustomize.py").write_text(
+        "# Temporary workaround for deepmodeling/deepmd-kit#5559.\ntry:\n    import deepmd_gnn.pt_expt  # noqa: F401\nexcept Exception as exc:\n    raise SystemExit(\n        f'Failed to register deepmd-gnn pt_expt plugin: {exc}'\n    ) from exc\n",
+    )

--- a/tests/test_lammps.py
+++ b/tests/test_lammps.py
@@ -17,7 +17,7 @@ import numpy as np
 import pytest
 
 from tests._pt_expt import (
-    register_pt_expt_plugin_for_cli,
+    pt_expt_cli_env,
 )
 
 REPO_ROOT = Path(__file__).resolve().parents[1]
@@ -156,11 +156,11 @@ def _freeze_mace_model(tmp_path: Path, backend_flag: str) -> Path:
     work_dir = tmp_path / "model"
     shutil.copytree(WATER_DATA, work_dir / "data")
     shutil.copy(MACE_INPUT, work_dir / "mace.json")
-    if backend_flag == "--pt-expt":
-        register_pt_expt_plugin_for_cli(work_dir)
 
     env = os.environ.copy()
     env.setdefault("OMP_NUM_THREADS", "1")
+    if backend_flag == "--pt-expt":
+        env = pt_expt_cli_env(work_dir, env)
     _run_command(
         [sys.executable, "-m", "deepmd", backend_flag, "train", "mace.json"],
         work_dir,

--- a/tests/test_lammps.py
+++ b/tests/test_lammps.py
@@ -16,9 +16,18 @@ from typing import NoReturn
 import numpy as np
 import pytest
 
+from tests._pt_expt import (
+    register_pt_expt_plugin_for_cli,
+    require_deepmd_kit_pt2_support,
+)
+
 REPO_ROOT = Path(__file__).resolve().parents[1]
 WATER_DATA = REPO_ROOT / "tests" / "data"
 MACE_INPUT = REPO_ROOT / "tests" / "mace.json"
+MODEL_BACKENDS = [
+    pytest.param("--pt", id="pt"),
+    pytest.param("--pt-expt", id="pt-expt"),
+]
 SIX_ATOM_BOX = np.array([0.0, 13.0, 0.0, 13.0, 0.0, 13.0, 0.0, 0.0, 0.0])
 SIX_ATOM_COORD = np.array(
     [
@@ -144,22 +153,33 @@ def _run_command(command: list[str], cwd: Path, env: dict[str, str]) -> None:
     assert result.returncode == 0, result.stdout + result.stderr
 
 
-def _freeze_mace_model(tmp_path: Path) -> Path:
+def _require_model_backend(backend_flag: str) -> None:
+    if backend_flag == "--pt-expt":
+        require_deepmd_kit_pt2_support()
+
+
+def _freeze_mace_model(tmp_path: Path, backend_flag: str) -> Path:
+    _require_model_backend(backend_flag)
+
     work_dir = tmp_path / "model"
     shutil.copytree(WATER_DATA, work_dir / "data")
     shutil.copy(MACE_INPUT, work_dir / "mace.json")
+    if backend_flag == "--pt-expt":
+        register_pt_expt_plugin_for_cli(work_dir)
 
     env = os.environ.copy()
     env.setdefault("OMP_NUM_THREADS", "1")
     _run_command(
-        [sys.executable, "-m", "deepmd", "--pt", "train", "mace.json"],
+        [sys.executable, "-m", "deepmd", backend_flag, "train", "mace.json"],
         work_dir,
         env,
     )
 
-    model_file = work_dir / "model.pth"
+    model_file = work_dir / (
+        "model.pt2" if backend_flag == "--pt-expt" else "model.pth"
+    )
     _run_command(
-        [sys.executable, "-m", "deepmd", "--pt", "freeze", "-o", str(model_file)],
+        [sys.executable, "-m", "deepmd", backend_flag, "freeze", "-o", str(model_file)],
         work_dir,
         env,
     )
@@ -312,11 +332,16 @@ def _read_step_zero_pe(log_file: Path) -> float:
 
 
 @pytest.mark.lammps
-def test_lammps_runs_six_atom_mace_model(tmp_path: Path) -> None:
+@pytest.mark.parametrize("backend_flag", MODEL_BACKENDS)
+def test_lammps_runs_six_atom_mace_model(
+    tmp_path: Path,
+    backend_flag: str,
+) -> None:
     """Run one LAMMPS step with a frozen MACE model through DeePMD-kit."""
+    _require_model_backend(backend_flag)
     _ensure_lammps_available()
     lammps_env = _lammps_env()
-    model_file = _freeze_mace_model(tmp_path)
+    model_file = _freeze_mace_model(tmp_path, backend_flag)
 
     data_file = tmp_path / "water.lmp"
     input_file = tmp_path / "in.lammps"
@@ -331,12 +356,17 @@ def test_lammps_runs_six_atom_mace_model(tmp_path: Path) -> None:
 
 @pytest.mark.lammps
 @pytest.mark.mpi
-def test_lammps_mpi_matches_single_rank_six_atom_mace_model(tmp_path: Path) -> None:
+@pytest.mark.parametrize("backend_flag", MODEL_BACKENDS)
+def test_lammps_mpi_matches_single_rank_six_atom_mace_model(
+    tmp_path: Path,
+    backend_flag: str,
+) -> None:
     """Run frozen MACE through DeePMD-kit with two MPI ranks."""
+    _require_model_backend(backend_flag)
     _ensure_lammps_available()
     _ensure_mpi_lammps_available()
     lammps_env = _lammps_env()
-    model_file = _freeze_mace_model(tmp_path)
+    model_file = _freeze_mace_model(tmp_path, backend_flag)
 
     data_file = tmp_path / "water.lmp"
     single_input = tmp_path / "in.single.lammps"

--- a/tests/test_lammps.py
+++ b/tests/test_lammps.py
@@ -18,7 +18,6 @@ import pytest
 
 from tests._pt_expt import (
     register_pt_expt_plugin_for_cli,
-    require_deepmd_kit_pt2_support,
 )
 
 REPO_ROOT = Path(__file__).resolve().parents[1]
@@ -153,14 +152,7 @@ def _run_command(command: list[str], cwd: Path, env: dict[str, str]) -> None:
     assert result.returncode == 0, result.stdout + result.stderr
 
 
-def _require_model_backend(backend_flag: str) -> None:
-    if backend_flag == "--pt-expt":
-        require_deepmd_kit_pt2_support()
-
-
 def _freeze_mace_model(tmp_path: Path, backend_flag: str) -> Path:
-    _require_model_backend(backend_flag)
-
     work_dir = tmp_path / "model"
     shutil.copytree(WATER_DATA, work_dir / "data")
     shutil.copy(MACE_INPUT, work_dir / "mace.json")
@@ -338,7 +330,6 @@ def test_lammps_runs_six_atom_mace_model(
     backend_flag: str,
 ) -> None:
     """Run one LAMMPS step with a frozen MACE model through DeePMD-kit."""
-    _require_model_backend(backend_flag)
     _ensure_lammps_available()
     lammps_env = _lammps_env()
     model_file = _freeze_mace_model(tmp_path, backend_flag)
@@ -362,7 +353,6 @@ def test_lammps_mpi_matches_single_rank_six_atom_mace_model(
     backend_flag: str,
 ) -> None:
     """Run frozen MACE through DeePMD-kit with two MPI ranks."""
-    _require_model_backend(backend_flag)
     _ensure_lammps_available()
     _ensure_mpi_lammps_available()
     lammps_env = _lammps_env()

--- a/tests/test_lammps.py
+++ b/tests/test_lammps.py
@@ -228,6 +228,7 @@ def _write_lammps_input(
                 "units metal",
                 "boundary p p p",
                 "atom_style atomic",
+                "atom_modify map yes",
                 "neighbor 2.0 bin",
                 "neigh_modify every 1 delay 0 check yes",
                 *processor_commands,

--- a/tests/test_lammps.py
+++ b/tests/test_lammps.py
@@ -18,6 +18,7 @@ import pytest
 
 from tests._pt_expt import (
     pt_expt_cli_env,
+    skip_cuda_pt_expt_aoti_if_requested,
 )
 
 REPO_ROOT = Path(__file__).resolve().parents[1]
@@ -180,6 +181,7 @@ def _freeze_model(tmp_path: Path, model_name: str, backend_flag: str) -> Path:
     env.setdefault("OMP_NUM_THREADS", "1")
     _configure_mpi_runtime_env(env)
     if backend_flag == "--pt-expt":
+        skip_cuda_pt_expt_aoti_if_requested()
         env = pt_expt_cli_env(work_dir, env)
     _run_command(
         [sys.executable, "-m", "deepmd", backend_flag, "train", input_path.name],

--- a/tests/test_lammps.py
+++ b/tests/test_lammps.py
@@ -380,6 +380,10 @@ def test_lammps_mpi_matches_single_rank_six_atom_mace_model(
     backend_flag: str,
 ) -> None:
     """Run frozen MACE through DeePMD-kit with two MPI ranks."""
+    if backend_flag == "--pt-expt":
+        pytest.skip(
+            "multi-rank .pt2 LAMMPS requires a deepmd-kit with-comm artifact",
+        )
     _ensure_lammps_available()
     _ensure_mpi_lammps_available()
     lammps_env = _lammps_env()

--- a/tests/test_lammps.py
+++ b/tests/test_lammps.py
@@ -56,6 +56,12 @@ def _prepend_env_path(env: dict[str, str], name: str, *paths: Path | str) -> Non
     env[name] = os.pathsep.join(entries)
 
 
+def _configure_mpi_runtime_env(env: dict[str, str]) -> None:
+    # GitHub-hosted Azure runners expose a MANA interface that MPICH/UCX may
+    # select as ud_verbs, but that path fails during MPI_Init in this job.
+    env.setdefault("UCX_TLS", "tcp,self")
+
+
 def _deepmd_lib_dir() -> Path:
     try:
         deepmd_env = importlib.import_module("deepmd.env")
@@ -122,6 +128,7 @@ def _lammps_env() -> dict[str, str]:
     env.setdefault("OMP_NUM_THREADS", "1")
     env.setdefault("OMPI_ALLOW_RUN_AS_ROOT", "1")
     env.setdefault("OMPI_ALLOW_RUN_AS_ROOT_CONFIRM", "1")
+    _configure_mpi_runtime_env(env)
 
     if platform.system() == "Darwin":
         lib_env = "DYLD_FALLBACK_LIBRARY_PATH"
@@ -159,6 +166,7 @@ def _freeze_mace_model(tmp_path: Path, backend_flag: str) -> Path:
 
     env = os.environ.copy()
     env.setdefault("OMP_NUM_THREADS", "1")
+    _configure_mpi_runtime_env(env)
     if backend_flag == "--pt-expt":
         env = pt_expt_cli_env(work_dir, env)
     _run_command(

--- a/tests/test_lammps.py
+++ b/tests/test_lammps.py
@@ -243,6 +243,24 @@ def _write_lammps_input(
     )
 
 
+def _lammps_failure_message(
+    result: subprocess.CompletedProcess[str],
+    log_file: Path,
+) -> str:
+    log_text = log_file.read_text() if log_file.exists() else "<missing log file>"
+    return "\n".join(
+        [
+            f"LAMMPS exited with status {result.returncode}",
+            "=== stdout ===",
+            result.stdout,
+            "=== stderr ===",
+            result.stderr,
+            f"=== {log_file.name} ===",
+            log_text,
+        ],
+    )
+
+
 def _run_lammps(input_file: Path, log_file: Path, env: dict[str, str]) -> None:
     lmp = shutil.which("lmp") or shutil.which("lmp_serial")
     if lmp is not None:
@@ -255,7 +273,7 @@ def _run_lammps(input_file: Path, log_file: Path, env: dict[str, str]) -> None:
             timeout=120,
             check=False,
         )
-        assert result.returncode == 0, result.stdout + result.stderr
+        assert result.returncode == 0, _lammps_failure_message(result, log_file)
         return
 
     try:
@@ -306,7 +324,7 @@ def _run_lammps_mpi(
         timeout=180,
         check=False,
     )
-    assert result.returncode == 0, result.stdout + result.stderr
+    assert result.returncode == 0, _lammps_failure_message(result, log_file)
 
 
 def _read_step_zero_pe(log_file: Path) -> float:

--- a/tests/test_lammps.py
+++ b/tests/test_lammps.py
@@ -32,7 +32,6 @@ MODEL_CASES = [
     pytest.param("mace", "--pt", id="mace-pt"),
     pytest.param("mace", "--pt-expt", id="mace-pt-expt"),
     pytest.param("nequip", "--pt", id="nequip-pt"),
-    pytest.param("nequip", "--pt-expt", id="nequip-pt-expt"),
 ]
 MODEL_MPI_PE_TOL = {
     "mace": {"atol": 1e-8, "rtol": 0.0},

--- a/tests/test_nequip_comm.py
+++ b/tests/test_nequip_comm.py
@@ -42,6 +42,19 @@ def test_nequip_serializes_with_nequip_type() -> None:
     assert model.serialize()["type"] == "nequip"
 
 
+def test_nequip_export_metadata_defaults() -> None:
+    """NeQuIP advertises the default optional backend metadata."""
+    model = _make_nequip_model()
+
+    assert model.atomic_output_def() is not None
+    assert model.has_default_fparam() is False
+    assert model.get_default_fparam() is None
+    assert model.has_chg_spin_ebd() is False
+    assert model.get_dim_chg_spin() == 0
+    assert model.has_default_chg_spin() is False
+    assert model.get_default_chg_spin() is None
+
+
 def test_nequip_comm_branch_matches_regular_lower_without_ghosts(monkeypatch) -> None:
     """Identity communication should reproduce the regular lower path."""
 

--- a/tests/test_nequip_comm.py
+++ b/tests/test_nequip_comm.py
@@ -35,6 +35,13 @@ def _empty_comm_dict() -> dict[str, torch.Tensor]:
     }
 
 
+def test_nequip_serializes_with_nequip_type() -> None:
+    """NequIP checkpoints should deserialize through NequipModel, not MaceModel."""
+    model = _make_nequip_model()
+
+    assert model.serialize()["type"] == "nequip"
+
+
 def test_nequip_comm_branch_matches_regular_lower_without_ghosts(monkeypatch) -> None:
     """Identity communication should reproduce the regular lower path."""
 

--- a/tests/test_op.py
+++ b/tests/test_op.py
@@ -4,7 +4,7 @@ import pytest
 import torch
 
 import deepmd_gnn.op  # noqa: F401
-from deepmd_gnn.edge import dense_edge_index
+from deepmd_gnn.edge import _fake_dense_edge_index, dense_edge_index
 
 
 def test_one_frame() -> None:
@@ -163,3 +163,25 @@ def test_cuda_matches_cpu() -> None:
     torch.testing.assert_close(edge_index.cpu(), expected_edge_index)
     assert legacy_edge_index.is_cuda
     torch.testing.assert_close(legacy_edge_index.cpu(), expected_edge_index)
+
+
+def test_fake_dense_edge_index_handles_2d_nlist() -> None:
+    """Fake dense edge op should preserve the flattened 2D nlist size."""
+    nlist = torch.empty((3, 4), dtype=torch.int64)
+    atype = torch.empty((3,), dtype=torch.int64)
+    mm_types = torch.empty((2,), dtype=torch.int64)
+
+    edge_index, edge_mask = _fake_dense_edge_index(nlist, atype, mm_types)
+
+    assert edge_index.shape == (12, 2)
+    assert edge_mask.shape == (12,)
+
+
+def test_fake_dense_edge_index_rejects_invalid_rank() -> None:
+    """Fake dense edge op should match the real op rank contract."""
+    nlist = torch.empty((1, 2, 3, 4), dtype=torch.int64)
+    atype = torch.empty((1, 2), dtype=torch.int64)
+    mm_types = torch.empty((2,), dtype=torch.int64)
+
+    with pytest.raises(ValueError, match="nlist must be 2D or 3D"):
+        _fake_dense_edge_index(nlist, atype, mm_types)

--- a/tests/test_op.py
+++ b/tests/test_op.py
@@ -4,6 +4,7 @@ import pytest
 import torch
 
 import deepmd_gnn.op  # noqa: F401
+from deepmd_gnn.edge import dense_edge_index
 
 
 def test_one_frame() -> None:
@@ -39,8 +40,14 @@ def test_one_frame() -> None:
         extended_atype_ff,
         torch.tensor(mm_types, dtype=torch.int64, device="cpu"),
     )
+    dense_edge_index_, edge_mask = dense_edge_index(
+        nlist_ff,
+        extended_atype_ff,
+        mm_types,
+    )
 
     assert torch.equal(edge_index, expected_edge_index)
+    assert torch.equal(dense_edge_index_[edge_mask], expected_edge_index)
 
 
 def test_two_frame() -> None:
@@ -70,6 +77,7 @@ def test_two_frame() -> None:
         device="cpu",
     )
     mm_types = [1, 2]
+    mm_tensor = torch.tensor(mm_types, dtype=torch.int64, device="cpu")
     expected_edge_index = torch.tensor(
         [
             [1, 0],
@@ -88,17 +96,21 @@ def test_two_frame() -> None:
     edge_index = torch.ops.deepmd_gnn.edge_index(
         nlist,
         extended_atype,
-        torch.tensor(mm_types, dtype=torch.int64, device="cpu"),
+        mm_tensor,
     )
-
-    assert torch.equal(edge_index, expected_edge_index)
-
+    dense_edge_index_, edge_mask = dense_edge_index(
+        nlist,
+        extended_atype,
+        mm_types,
+    )
     legacy_edge_index = torch.ops.deepmd_mace.mace_edge_index(
         nlist,
         extended_atype,
-        torch.tensor(mm_types, dtype=torch.int64, device="cpu"),
+        mm_tensor,
     )
 
+    assert torch.equal(edge_index, expected_edge_index)
+    assert torch.equal(dense_edge_index_[edge_mask], expected_edge_index)
     assert torch.equal(legacy_edge_index, expected_edge_index)
 
 

--- a/tests/test_pt_expt.py
+++ b/tests/test_pt_expt.py
@@ -1,6 +1,9 @@
 # SPDX-License-Identifier: LGPL-3.0-or-later
 """Tests for DeePMD-kit's PyTorch exportable backend integration."""
 
+import sys
+import types
+
 import pytest
 import torch
 from deepmd.pt.model.model.model import (
@@ -15,9 +18,15 @@ from deepmd.pt_expt.utils.serialization import (
 )
 
 import deepmd_gnn.pt
-import deepmd_gnn.pt_expt  # noqa: F401
+import deepmd_gnn.pt_expt
 from deepmd_gnn.mace import MaceModel
 from deepmd_gnn.nequip import NequipModel
+
+
+def test_pt_expt_registration_defers_during_partial_mace_import(monkeypatch) -> None:
+    """Registration is skipped while the MACE module is partially initialized."""
+    monkeypatch.setitem(sys.modules, "deepmd_gnn.mace", types.ModuleType("mace"))
+    deepmd_gnn.pt_expt._register()  # noqa: SLF001
 
 
 def test_pt_and_pt_expt_entry_points_register_models() -> None:

--- a/tests/test_pt_expt.py
+++ b/tests/test_pt_expt.py
@@ -1,0 +1,61 @@
+# SPDX-License-Identifier: LGPL-3.0-or-later
+"""Tests for DeePMD-kit's PyTorch exportable backend integration."""
+
+import torch
+from deepmd.pt.model.model.model import (
+    BaseModel as PtBaseModel,
+)
+from deepmd.pt_expt.model.model import (
+    BaseModel as PtExptBaseModel,
+)
+from deepmd.pt_expt.utils.serialization import (
+    _build_dynamic_shapes,
+    _make_sample_inputs,
+)
+
+import deepmd_gnn.pt
+import deepmd_gnn.pt_expt  # noqa: F401
+from deepmd_gnn.mace import MaceModel
+from deepmd_gnn.nequip import NequipModel
+
+
+def test_pt_and_pt_expt_entry_points_register_models() -> None:
+    """Model classes are available through both PyTorch backend registries."""
+    assert PtBaseModel.get_class_by_type("mace") is MaceModel
+    assert PtBaseModel.get_class_by_type("nequip") is NequipModel
+    assert PtExptBaseModel.get_class_by_type("mace") is MaceModel
+    assert PtExptBaseModel.get_class_by_type("nequip") is NequipModel
+
+
+def test_mace_pt_expt_export_handles_dynamic_nloc(tmp_path) -> None:
+    """Exported MACE graph keeps atom-count dimensions dynamic after save/load."""
+    model = MaceModel(type_map=["O", "H"], r_max=6.0, sel=116, hidden_irreps="16x0e")
+    sample_inputs = _make_sample_inputs(model, nframes=2, nloc=2)
+    extended_coord, extended_atype, nlist, mapping, fparam, aparam = sample_inputs
+    traced = model.forward_common_lower_exportable(
+        extended_coord,
+        extended_atype,
+        nlist,
+        mapping,
+        fparam,
+        aparam,
+        do_atomic_virial=True,
+        tracing_mode="symbolic",
+        _allow_non_fake_inputs=True,
+    )
+    exported = torch.export.export(
+        traced,
+        sample_inputs,
+        dynamic_shapes=_build_dynamic_shapes(*sample_inputs),
+        strict=False,
+    )
+    assert exported._guards_code == []  # noqa: SLF001
+
+    model_file = tmp_path / "model.pt2"
+    torch.export.save(exported, model_file)
+    module = torch.export.load(model_file).module()
+
+    for nloc in (2, 3):
+        inputs = _make_sample_inputs(model, nframes=2, nloc=nloc)
+        outputs = module(*inputs)
+        assert outputs["energy"].shape == (2, nloc, 1)

--- a/tests/test_pt_expt.py
+++ b/tests/test_pt_expt.py
@@ -49,16 +49,29 @@ def test_mace_pt_expt_export_handles_dynamic_nloc(tmp_path) -> None:
     exported = torch.export.export(
         traced,
         sample_inputs,
-        dynamic_shapes=_build_dynamic_shapes(*sample_inputs),
+        dynamic_shapes=_build_dynamic_shapes(
+            *sample_inputs,
+            model_nnei=sum(model.get_sel()),
+        ),
         strict=False,
     )
     assert exported._guards_code == []  # noqa: SLF001
+    assert not any(
+        node.op == "call_function"
+        and node.target is torch.ops.aten._assert_scalar.default  # noqa: SLF001
+        for node in exported.graph_module.graph.nodes
+    )
+    assert all(
+        value_range.lower <= 1 for value_range in exported.range_constraints.values()
+    )
 
     model_file = tmp_path / "model.pt2"
     torch.export.save(exported, model_file)
     module = torch.export.load(model_file).module()
 
-    for nloc in (2, 3):
-        inputs = _make_sample_inputs(model, nframes=2, nloc=nloc)
-        outputs = module(*inputs)
+    for nloc, nnei in ((2, model.get_nnei()), (3, 48)):
+        inputs = list(_make_sample_inputs(model, nframes=2, nloc=nloc))
+        inputs[2] = inputs[2][..., :nnei]
+        runtime_inputs = tuple(inputs)
+        outputs = module(*runtime_inputs)
         assert outputs["energy"].shape == (2, nloc, 1)

--- a/tests/test_pt_expt.py
+++ b/tests/test_pt_expt.py
@@ -1,6 +1,7 @@
 # SPDX-License-Identifier: LGPL-3.0-or-later
 """Tests for DeePMD-kit's PyTorch exportable backend integration."""
 
+import pytest
 import torch
 from deepmd.pt.model.model.model import (
     BaseModel as PtBaseModel,
@@ -20,11 +21,12 @@ from deepmd_gnn.nequip import NequipModel
 
 
 def test_pt_and_pt_expt_entry_points_register_models() -> None:
-    """Model classes are available through both PyTorch backend registries."""
+    """Model classes are available through their supported backend registries."""
     assert PtBaseModel.get_class_by_type("mace") is MaceModel
     assert PtBaseModel.get_class_by_type("nequip") is NequipModel
     assert PtExptBaseModel.get_class_by_type("mace") is MaceModel
-    assert PtExptBaseModel.get_class_by_type("nequip") is NequipModel
+    with pytest.raises(RuntimeError, match="Unknown model type: nequip"):
+        PtExptBaseModel.get_class_by_type("nequip")
 
 
 def test_mace_pt_expt_export_handles_dynamic_nloc(tmp_path) -> None:

--- a/tests/test_pt_expt.py
+++ b/tests/test_pt_expt.py
@@ -31,7 +31,9 @@ def test_mace_pt_expt_export_handles_dynamic_nloc(tmp_path) -> None:
     """Exported MACE graph keeps atom-count dimensions dynamic after save/load."""
     model = MaceModel(type_map=["O", "H"], r_max=6.0, sel=116, hidden_irreps="16x0e")
     sample_inputs = _make_sample_inputs(model, nframes=2, nloc=2)
-    extended_coord, extended_atype, nlist, mapping, fparam, aparam = sample_inputs
+    extended_coord, extended_atype, nlist, mapping, fparam, aparam, charge_spin = (
+        sample_inputs
+    )
     traced = model.forward_common_lower_exportable(
         extended_coord,
         extended_atype,
@@ -39,6 +41,7 @@ def test_mace_pt_expt_export_handles_dynamic_nloc(tmp_path) -> None:
         mapping,
         fparam,
         aparam,
+        charge_spin,
         do_atomic_virial=True,
         tracing_mode="symbolic",
         _allow_non_fake_inputs=True,

--- a/tests/test_pt_expt.py
+++ b/tests/test_pt_expt.py
@@ -29,6 +29,12 @@ def test_pt_expt_registration_defers_during_partial_mace_import(monkeypatch) -> 
     deepmd_gnn.pt_expt._register()  # noqa: SLF001
 
 
+def test_pt_registration_defers_during_partial_nequip_import(monkeypatch) -> None:
+    """PyTorch registration is skipped while the NeQuIP module initializes."""
+    monkeypatch.setitem(sys.modules, "deepmd_gnn.nequip", types.ModuleType("nequip"))
+    deepmd_gnn.pt._register()  # noqa: SLF001
+
+
 def test_pt_and_pt_expt_entry_points_register_models() -> None:
     """Model classes are available through their supported backend registries."""
     assert PtBaseModel.get_class_by_type("mace") is MaceModel
@@ -36,6 +42,18 @@ def test_pt_and_pt_expt_entry_points_register_models() -> None:
     assert PtExptBaseModel.get_class_by_type("mace") is MaceModel
     with pytest.raises(RuntimeError, match="Unknown model type: nequip"):
         PtExptBaseModel.get_class_by_type("nequip")
+
+
+def test_mace_export_metadata_defaults() -> None:
+    """MACE advertises the default optional pt_expt input metadata."""
+    model = MaceModel(type_map=["O", "H"], r_max=6.0, sel=4, hidden_irreps="16x0e")
+
+    assert model.atomic_output_def() is not None
+    assert model.has_default_fparam() is False
+    assert model.get_default_fparam() is None
+    assert model.has_chg_spin_ebd() is False
+    assert model.has_default_chg_spin() is False
+    assert model.get_default_chg_spin() is None
 
 
 def test_mace_pt_expt_export_handles_dynamic_nloc(tmp_path) -> None:

--- a/tests/test_training.py
+++ b/tests/test_training.py
@@ -8,18 +8,13 @@ from pathlib import Path
 
 import pytest
 
-
-@pytest.mark.parametrize(
-    "input_fn",
-    [
-        "mace.json",
-        "nequip.json",
-    ],
+from tests._pt_expt import (
+    register_pt_expt_plugin_for_cli,
+    require_deepmd_kit_pt2_support,
 )
-def test_e2e_training(input_fn) -> None:
-    """Test training the model."""
-    model_fn = "model.pth"
-    # create temp directory and copy example files
+
+
+def _run_e2e_training(input_fn, backend_flag: str, model_fn: str) -> None:
     with tempfile.TemporaryDirectory() as _tmpdir:
         tmpdir = Path(_tmpdir)
         this_dir = Path(__file__).parent
@@ -29,13 +24,15 @@ def test_e2e_training(input_fn) -> None:
         shutil.copytree(data_path, tmpdir / "data")
         # copy input.json to tmpdir
         shutil.copy(input_path, tmpdir / input_fn)
+        if backend_flag == "--pt-expt":
+            register_pt_expt_plugin_for_cli(tmpdir)
 
         subprocess.check_call(
             [
                 sys.executable,
                 "-m",
                 "deepmd",
-                "--pt",
+                backend_flag,
                 "train",
                 input_fn,
             ],
@@ -46,7 +43,7 @@ def test_e2e_training(input_fn) -> None:
                 sys.executable,
                 "-m",
                 "deepmd",
-                "--pt",
+                backend_flag,
                 "freeze",
                 "-o",
                 model_fn,
@@ -54,3 +51,28 @@ def test_e2e_training(input_fn) -> None:
             cwd=tmpdir,
         )
         assert (tmpdir / model_fn).exists()
+
+
+@pytest.mark.parametrize(
+    "input_fn",
+    [
+        "mace.json",
+        "nequip.json",
+    ],
+)
+def test_e2e_training(input_fn) -> None:
+    """Test training the model."""
+    _run_e2e_training(input_fn, "--pt", "model.pth")
+
+
+@pytest.mark.parametrize(
+    "input_fn",
+    [
+        "mace.json",
+        "nequip.json",
+    ],
+)
+def test_e2e_pt_expt_training_exports_pt2(input_fn) -> None:
+    """Test training and freezing exportable models for LAMMPS."""
+    require_deepmd_kit_pt2_support()
+    _run_e2e_training(input_fn, "--pt-expt", "model.pt2")

--- a/tests/test_training.py
+++ b/tests/test_training.py
@@ -10,7 +10,6 @@ import pytest
 
 from tests._pt_expt import (
     register_pt_expt_plugin_for_cli,
-    require_deepmd_kit_pt2_support,
 )
 
 
@@ -74,5 +73,4 @@ def test_e2e_training(input_fn) -> None:
 )
 def test_e2e_pt_expt_training_exports_pt2(input_fn) -> None:
     """Test training and freezing exportable models for LAMMPS."""
-    require_deepmd_kit_pt2_support()
     _run_e2e_training(input_fn, "--pt-expt", "model.pt2")

--- a/tests/test_training.py
+++ b/tests/test_training.py
@@ -10,6 +10,7 @@ import pytest
 
 from tests._pt_expt import (
     pt_expt_cli_env,
+    skip_cuda_pt_expt_aoti_if_requested,
 )
 
 
@@ -75,4 +76,5 @@ def test_e2e_training(input_fn) -> None:
 )
 def test_e2e_pt_expt_training_exports_pt2(input_fn) -> None:
     """Test training and freezing exportable models for LAMMPS."""
+    skip_cuda_pt_expt_aoti_if_requested()
     _run_e2e_training(input_fn, "--pt-expt", "model.pt2")

--- a/tests/test_training.py
+++ b/tests/test_training.py
@@ -71,7 +71,6 @@ def test_e2e_training(input_fn) -> None:
     "input_fn",
     [
         "mace.json",
-        "nequip.json",
     ],
 )
 def test_e2e_pt_expt_training_exports_pt2(input_fn) -> None:

--- a/tests/test_training.py
+++ b/tests/test_training.py
@@ -9,7 +9,7 @@ from pathlib import Path
 import pytest
 
 from tests._pt_expt import (
-    register_pt_expt_plugin_for_cli,
+    pt_expt_cli_env,
 )
 
 
@@ -23,8 +23,9 @@ def _run_e2e_training(input_fn, backend_flag: str, model_fn: str) -> None:
         shutil.copytree(data_path, tmpdir / "data")
         # copy input.json to tmpdir
         shutil.copy(input_path, tmpdir / input_fn)
+        env = None
         if backend_flag == "--pt-expt":
-            register_pt_expt_plugin_for_cli(tmpdir)
+            env = pt_expt_cli_env(tmpdir)
 
         subprocess.check_call(
             [
@@ -36,6 +37,7 @@ def _run_e2e_training(input_fn, backend_flag: str, model_fn: str) -> None:
                 input_fn,
             ],
             cwd=tmpdir,
+            env=env,
         )
         subprocess.check_call(
             [
@@ -48,6 +50,7 @@ def _run_e2e_training(input_fn, backend_flag: str, model_fn: str) -> None:
                 model_fn,
             ],
             cwd=tmpdir,
+            env=env,
         )
         assert (tmpdir / model_fn).exists()
 


### PR DESCRIPTION
Summary:
- register MACE/NequIP for both deepmd.pt and deepmd.pt_expt entry points
- add a fixed-size dense C++ edge-index op with fake implementation for torch.export
- route pt_expt export paths through the dense C++ op while keeping TorchScript/PT paths on the existing compact C++ op
- add coverage for dense edge masking and MACE pt_expt dynamic-nloc export/save/load

Tests:
- pre-commit hook during commit: ruff, ruff format, mypy, clang-format, and standard checks passed
- python -m ruff check deepmd_gnn/edge.py deepmd_gnn/mace.py deepmd_gnn/nequip.py deepmd_gnn/pt.py deepmd_gnn/pt_expt.py tests/test_op.py tests/test_pt_expt.py
- python -m ruff format --check deepmd_gnn/edge.py deepmd_gnn/mace.py deepmd_gnn/nequip.py deepmd_gnn/pt.py deepmd_gnn/pt_expt.py tests/test_op.py tests/test_pt_expt.py
- python -m compileall -q deepmd_gnn/edge.py deepmd_gnn/mace.py deepmd_gnn/nequip.py deepmd_gnn/pt.py deepmd_gnn/pt_expt.py tests/test_op.py tests/test_pt_expt.py
- git diff --check

Not run locally:
- runtime pytest/dp train/freeze/LAMMPS after rebuilding the C++ extension, because this environment lacks scikit_build_core and the installed extension is still the old build without deepmd_gnn::dense_edge_index.