### PR TITLE
Support NequIP border_op communication

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ Supported packages and models include:
 - [MACE](https://github.com/ACEsuit/mace) (PyTorch version)
 - [NequIP](https://github.com/mir-group/nequip) (PyTorch version)
 
-After [installing the plugin](#installation), you can train the GNN models using DeePMD-kit, run active learning cycles for the GNN models using [DP-GEN](https://github.com/deepmodeling/dpgen), perform simulations with the MACE model using molecular dynamic packages supported by DeePMD-kit, such as [LAMMPS](https://github.com/lammps/lammps) and [AMBER](https://ambermd.org/).
+After [installing the plugin](#installation), you can train the GNN models using DeePMD-kit, run active learning cycles for the GNN models using [DP-GEN](https://github.com/deepmodeling/dpgen), and perform simulations with MACE and NequIP models using molecular dynamic packages supported by DeePMD-kit, such as [LAMMPS](https://github.com/lammps/lammps) and [AMBER](https://ambermd.org/).
 You can follow [DeePMD-kit documentation](https://docs.deepmodeling.com/projects/deepmd/en/latest/) to train the GNN models using its PyTorch backend, after using the specific [model parameters](#parameters).
 
 ## Credits
@@ -86,29 +86,25 @@ dp --pt freeze
 A frozen model file named `frozen_model.pth` will be generated. You can use it in the MD packages or other interfaces.
 For details, follow [DeePMD-kit documentation](https://docs.deepmodeling.com/projects/deepmd/en/latest/).
 
-### Running LAMMPS + MACE with period boundary conditions
+### Running LAMMPS + GNN models with period boundary conditions
 
 GNN models use message passing neural networks,
 so the neighbor list built with traditional cutoff radius will not work,
 since the ghost atoms also need to build neighbor list.
-For NequIP, the model requests the neighbor list with a cutoff radius of $r_c \times N_{L}$,
-where $r_c$ is set by `r_max` and $N_L$ is set by `num_layers`,
-and rebuilds the neighbor list for ghost atoms.
-However, this approach is very inefficient.
-
-The MACE model works like a regular DeePMD-kit message-passing model.
+The MACE and NequIP models work like regular DeePMD-kit message-passing models.
 No extra environment variable is needed when freezing the model.
-It advertises message passing to DeePMD-kit, so LAMMPS can use the regular
+They advertise message passing to DeePMD-kit, so LAMMPS can use the regular
 neighbor list with a cutoff radius of $r_c$ and DeePMD-kit communicates
 the ghost-atom features through MPI between message-passing layers.
 This requires a DeePMD-kit build whose LAMMPS/PyTorch interface provides
 the message-passing communication op, `border_op`.
 
-The non-MPI mapping approach is still available for the MACE model
-(note: NequIP doesn't support such approach), but it does not support MPI.
-Request the mapping when using LAMMPS (also requires DeePMD-kit v3.0.0rc0 or above).
-By using the mapping, the ghost atoms will be mapped to the real atoms,
-so the regular neighbor list with a cutoff radius of $r_c$ can be used.
+When `border_op` communication is available, DeePMD-kit/LAMMPS uses that
+MPI-capable path. The atom-map path is a serial fallback for runs that do not
+receive a DeePMD message-passing `comm_dict`; it maps ghost atoms to their
+corresponding real atoms on the same process and is not a substitute for MPI
+communication. Request the mapping when using this fallback in LAMMPS
+(also requires DeePMD-kit v3.0.0rc0 or above).
 
 ```lammps
 atom_modify map array

--- a/deepmd_gnn/nequip.py
+++ b/deepmd_gnn/nequip.py
@@ -20,7 +20,6 @@ from deepmd.pt.utils import (
     env,
 )
 from deepmd.pt.utils.nlist import (
-    build_neighbor_list,
     extend_input_and_build_neighbor_list,
 )
 from deepmd.pt.utils.stat import (
@@ -45,9 +44,122 @@ from deepmd.utils.version import (
 from e3nn.util.jit import (
     script,
 )
+from nequip.data import (
+    AtomicDataDict,
+)
 from nequip.model import model_from_config
+from nequip.nn import (
+    GraphModel,
+    GraphModuleMixin,
+)
 
+import deepmd_gnn.op  # noqa: F401
 from deepmd_gnn.autograd import derive_atomic_virial_from_displacement
+
+if not hasattr(torch.ops.deepmd, "border_op"):  # pragma: no cover
+
+    def border_op(
+        _argument0: torch.Tensor,
+        _argument1: torch.Tensor,
+        _argument2: torch.Tensor,
+        _argument3: torch.Tensor,
+        _argument4: torch.Tensor,
+        _argument5: torch.Tensor,
+        _argument6: torch.Tensor,
+        _argument7: torch.Tensor,
+        _argument8: torch.Tensor,
+    ) -> list[torch.Tensor]:
+        """TorchScript placeholder used when DeePMD's PT op is not loaded."""
+        msg = (
+            "border_op is unavailable. Build/load DeePMD-kit's PyTorch OP "
+            "library before running MPI message-passing inference."
+        )
+        raise NotImplementedError(msg)
+
+    torch.ops.deepmd.border_op = border_op
+
+
+_COMM_SEND_LIST_KEY = "_deepmd_gnn_send_list"
+_COMM_SEND_PROC_KEY = "_deepmd_gnn_send_proc"
+_COMM_RECV_PROC_KEY = "_deepmd_gnn_recv_proc"
+_COMM_SEND_NUM_KEY = "_deepmd_gnn_send_num"
+_COMM_RECV_NUM_KEY = "_deepmd_gnn_recv_num"
+_COMM_COMMUNICATOR_KEY = "_deepmd_gnn_communicator"
+_COMM_NLOC_KEY = "_deepmd_gnn_nloc"
+_COMM_NGHOST_KEY = "_deepmd_gnn_nghost"
+_COMM_KEYS = [
+    _COMM_SEND_LIST_KEY,
+    _COMM_SEND_PROC_KEY,
+    _COMM_RECV_PROC_KEY,
+    _COMM_SEND_NUM_KEY,
+    _COMM_RECV_NUM_KEY,
+    _COMM_COMMUNICATOR_KEY,
+    _COMM_NLOC_KEY,
+    _COMM_NGHOST_KEY,
+]
+
+
+class _DeepMDBorderCommunication(GraphModuleMixin, torch.nn.Module):
+    """Communicate NequIP node features between message-passing layers."""
+
+    def __init__(self, irreps_in: dict[str, Any]) -> None:
+        super().__init__()
+        irreps_with_comm = dict(irreps_in)
+        for key in _COMM_KEYS:
+            irreps_with_comm[key] = None
+        self._init_irreps(irreps_in=irreps_with_comm, irreps_out={})
+
+    def forward(self, data: dict[str, torch.Tensor]) -> dict[str, torch.Tensor]:
+        """Communicate local node features to ghost slots when comm data is present."""
+        if "_deepmd_gnn_nloc" not in data:
+            return data
+
+        nloc_tensor = data["_deepmd_gnn_nloc"]
+        nghost_tensor = data["_deepmd_gnn_nghost"]
+        nloc = int(nloc_tensor.item())
+        nghost = int(nghost_tensor.item())
+
+        node_feats = data[AtomicDataDict.NODE_FEATURES_KEY][:nloc]
+        if nghost > 0:
+            node_feats = torch.nn.functional.pad(
+                node_feats,
+                (0, 0, 0, nghost),
+                value=0.0,
+            )
+
+        ret = torch.ops.deepmd.border_op(
+            data["_deepmd_gnn_send_list"],
+            data["_deepmd_gnn_send_proc"],
+            data["_deepmd_gnn_recv_proc"],
+            data["_deepmd_gnn_send_num"],
+            data["_deepmd_gnn_recv_num"],
+            node_feats,
+            data["_deepmd_gnn_communicator"],
+            nloc_tensor,
+            nghost_tensor,
+        )
+        data[AtomicDataDict.NODE_FEATURES_KEY] = ret[0]
+        return data
+
+
+def _insert_border_communication_modules(model: GraphModel, num_layers: int) -> None:
+    """Insert DeePMD border communication after NequIP convolution layers."""
+    if num_layers <= 1:
+        return
+
+    graph = model.model
+    for layer_idx in range(num_layers - 1):
+        conv_name = f"layer{layer_idx}_convnet"
+        comm_name = f"layer{layer_idx}_deepmd_comm"
+        conv_module = graph._modules[conv_name]  # noqa: SLF001
+        graph.insert(
+            name=comm_name,
+            module=_DeepMDBorderCommunication(conv_module.irreps_out),
+            after=conv_name,
+        )
+    for key in _COMM_KEYS:
+        if key not in model.model_input_fields:
+            model.model_input_fields.append(key)
 
 
 def _load_observed_type_stat_compat() -> tuple[Any, Any, Any]:
@@ -195,33 +307,33 @@ class NequipModel(BaseModel):
                 self.mm_types.append(ii)
 
         self.rcut = r_max
-        self.model = script(
-            model_from_config(
-                {
-                    "model_builders": ["EnergyModel"],
-                    "avg_num_neighbors": sel,
-                    "chemical_symbols": type_map,
-                    "num_types": self.ntypes,
-                    "r_max": r_max,
-                    "num_layers": num_layers,
-                    "l_max": l_max,
-                    "num_features": num_features,
-                    "nonlinearity_type": nonlinearity_type,
-                    "parity": parity,
-                    "num_basis": num_basis,
-                    "BesselBasis_trainable": BesselBasis_trainable,
-                    "PolynomialCutoff_p": PolynomialCutoff_p,
-                    "invariant_layers": invariant_layers,
-                    "invariant_neurons": invariant_neurons,
-                    "use_sc": use_sc,
-                    "irreps_edge_sh": irreps_edge_sh,
-                    "feature_irreps_hidden": feature_irreps_hidden,
-                    "chemical_embedding_irreps_out": chemical_embedding_irreps_out,
-                    "conv_to_output_hidden_irreps_out": conv_to_output_hidden_irreps_out,
-                    "model_dtype": precision,
-                },
-            ).to(env.DEVICE),
+        nequip_model = model_from_config(
+            {
+                "model_builders": ["EnergyModel"],
+                "avg_num_neighbors": sel,
+                "chemical_symbols": type_map,
+                "num_types": self.ntypes,
+                "r_max": r_max,
+                "num_layers": num_layers,
+                "l_max": l_max,
+                "num_features": num_features,
+                "nonlinearity_type": nonlinearity_type,
+                "parity": parity,
+                "num_basis": num_basis,
+                "BesselBasis_trainable": BesselBasis_trainable,
+                "PolynomialCutoff_p": PolynomialCutoff_p,
+                "invariant_layers": invariant_layers,
+                "invariant_neurons": invariant_neurons,
+                "use_sc": use_sc,
+                "irreps_edge_sh": irreps_edge_sh,
+                "feature_irreps_hidden": feature_irreps_hidden,
+                "chemical_embedding_irreps_out": chemical_embedding_irreps_out,
+                "conv_to_output_hidden_irreps_out": conv_to_output_hidden_irreps_out,
+                "model_dtype": precision,
+            },
         )
+        _insert_border_communication_modules(nequip_model, num_layers)
+        self.model = script(nequip_model.to(env.DEVICE))
         self.register_buffer(
             "e0",
             torch.zeros(
@@ -323,7 +435,7 @@ class NequipModel(BaseModel):
     @torch.jit.export
     def get_rcut(self) -> float:
         """Get the cut-off radius."""
-        return self.rcut * self.num_layers
+        return self.rcut
 
     @torch.jit.export
     def get_type_map(self) -> list[str]:
@@ -379,7 +491,7 @@ class NequipModel(BaseModel):
     @torch.jit.export
     def has_message_passing(self) -> bool:
         """Return whether the descriptor has message passing."""
-        return False
+        return self.num_layers > 1
 
     @torch.jit.export
     def forward(
@@ -485,17 +597,19 @@ class NequipModel(BaseModel):
             The communication dictionary.
         """
         nloc = nlist.shape[1]
-        nf, nall = extended_atype.shape
-        # recalculate nlist for ghost atoms
-        if self.num_layers > 1 and nloc < nall:
-            nlist = build_neighbor_list(
-                extended_coord.view(nf, -1),
-                extended_atype,
-                nall,
-                self.rcut * self.num_layers,
-                self.sel,
-                distinguish_types=False,
+        _nf, nall = extended_atype.shape
+        if (
+            self.num_layers > 1
+            and nloc < nall
+            and mapping is None
+            and comm_dict is None
+        ):
+            msg = (
+                "Multi-layer NequIP lower inference requires either comm_dict "
+                "from DeePMD-kit message-passing communication or a mapping "
+                "from extended atoms to local atoms."
             )
+            raise ValueError(msg)
         model_ret = self.forward_lower_common(
             nloc,
             extended_coord,
@@ -562,9 +676,6 @@ class NequipModel(BaseModel):
         if aparam is not None:
             msg = "aparam is unsupported"
             raise ValueError(msg)
-        if comm_dict is not None:
-            msg = "comm_dict is unsupported"
-            raise ValueError(msg)
         nlist = nlist.to(torch.int64)
         extended_atype = extended_atype.to(torch.int64)
         nall = extended_coord.shape[1]
@@ -596,7 +707,9 @@ class NequipModel(BaseModel):
             dtype=default_dtype,
             device=extended_coord_ff.device,
         )
-        if box is not None and mapping is not None and nloc < nall:
+        has_mapping = False
+        if comm_dict is None and mapping is not None and nloc < nall:
+            has_mapping = True
             mapping_ff = mapping.view(nf * nall) + torch.arange(
                 0,
                 nf * nall,
@@ -608,6 +721,26 @@ class NequipModel(BaseModel):
             shifts = shifts_atoms[edge_index[1]] - shifts_atoms[edge_index[0]]
             edge_index = mapping_ff[edge_index]
             input_dict["edge_index"] = edge_index
+        if comm_dict is not None:
+            if nf != 1:
+                msg = "NequIP comm_dict lower inference only supports one frame"
+                raise ValueError(msg)
+            input_dict["_deepmd_gnn_send_list"] = comm_dict["send_list"]
+            input_dict["_deepmd_gnn_send_proc"] = comm_dict["send_proc"]
+            input_dict["_deepmd_gnn_recv_proc"] = comm_dict["recv_proc"]
+            input_dict["_deepmd_gnn_send_num"] = comm_dict["send_num"]
+            input_dict["_deepmd_gnn_recv_num"] = comm_dict["recv_num"]
+            input_dict["_deepmd_gnn_communicator"] = comm_dict["communicator"]
+            input_dict["_deepmd_gnn_nloc"] = torch.tensor(
+                nloc,
+                dtype=torch.int32,
+                device=torch.device("cpu"),
+            )
+            input_dict["_deepmd_gnn_nghost"] = torch.tensor(
+                nall - nloc,
+                dtype=torch.int32,
+                device=torch.device("cpu"),
+            )
 
         batch = (
             torch.arange(
@@ -664,6 +797,19 @@ class NequipModel(BaseModel):
             input_dict["edge_cell_shift"] = edge_cell_shift
         else:
             input_dict["pos"] = extended_coord_ff
+            if has_mapping:
+                input_dict["batch"] = batch
+                input_dict["ptr"] = ptr
+                input_dict["cell"] = (
+                    torch.eye(
+                        3,
+                        dtype=extended_coord_ff.dtype,
+                        device=extended_coord_ff.device,
+                    )
+                    .unsqueeze(0)
+                    .expand(nf, 3, 3)
+                )
+                input_dict["edge_cell_shift"] = shifts
 
         ret = self.model.forward(
             input_dict,

--- a/tests/nequip.json
+++ b/tests/nequip.json
@@ -1,14 +1,22 @@
 {
   "_comment1": " model parameters",
   "model": {
-    "type": "mace",
+    "type": "nequip",
     "type_map": [
       "O",
       "H"
     ],
     "r_max": 6.0,
     "sel": "auto",
-    "hidden_irreps": "16x0e",
+    "num_layers": 2,
+    "l_max": 1,
+    "num_features": 8,
+    "num_basis": 4,
+    "invariant_layers": 1,
+    "invariant_neurons": 16,
+    "feature_irreps_hidden": "8x0e + 8x1o",
+    "chemical_embedding_irreps_out": "8x0e",
+    "conv_to_output_hidden_irreps_out": "8x0e",
     "_comment2": " that's all"
   },
 

--- a/tests/test_lammps.py
+++ b/tests/test_lammps.py
@@ -19,6 +19,11 @@ import pytest
 REPO_ROOT = Path(__file__).resolve().parents[1]
 WATER_DATA = REPO_ROOT / "tests" / "data"
 MACE_INPUT = REPO_ROOT / "tests" / "mace.json"
+NEQUIP_INPUT = REPO_ROOT / "tests" / "nequip.json"
+MODEL_INPUTS = {
+    "mace": MACE_INPUT,
+    "nequip": NEQUIP_INPUT,
+}
 SIX_ATOM_BOX = np.array([0.0, 13.0, 0.0, 13.0, 0.0, 13.0, 0.0, 0.0, 0.0])
 SIX_ATOM_COORD = np.array(
     [
@@ -144,20 +149,21 @@ def _run_command(command: list[str], cwd: Path, env: dict[str, str]) -> None:
     assert result.returncode == 0, result.stdout + result.stderr
 
 
-def _freeze_mace_model(tmp_path: Path) -> Path:
-    work_dir = tmp_path / "model"
+def _freeze_model(tmp_path: Path, model_name: str) -> Path:
+    input_path = MODEL_INPUTS[model_name]
+    work_dir = tmp_path / f"{model_name}_model"
     shutil.copytree(WATER_DATA, work_dir / "data")
-    shutil.copy(MACE_INPUT, work_dir / "mace.json")
+    shutil.copy(input_path, work_dir / input_path.name)
 
     env = os.environ.copy()
     env.setdefault("OMP_NUM_THREADS", "1")
     _run_command(
-        [sys.executable, "-m", "deepmd", "--pt", "train", "mace.json"],
+        [sys.executable, "-m", "deepmd", "--pt", "train", input_path.name],
         work_dir,
         env,
     )
 
-    model_file = work_dir / "model.pth"
+    model_file = work_dir / f"{model_name}.pth"
     _run_command(
         [sys.executable, "-m", "deepmd", "--pt", "freeze", "-o", str(model_file)],
         work_dir,
@@ -312,11 +318,12 @@ def _read_step_zero_pe(log_file: Path) -> float:
 
 
 @pytest.mark.lammps
-def test_lammps_runs_six_atom_mace_model(tmp_path: Path) -> None:
-    """Run one LAMMPS step with a frozen MACE model through DeePMD-kit."""
+@pytest.mark.parametrize("model_name", list(MODEL_INPUTS))
+def test_lammps_runs_six_atom_gnn_model(tmp_path: Path, model_name: str) -> None:
+    """Run one LAMMPS step with a frozen GNN model through DeePMD-kit."""
     _ensure_lammps_available()
     lammps_env = _lammps_env()
-    model_file = _freeze_mace_model(tmp_path)
+    model_file = _freeze_model(tmp_path, model_name)
 
     data_file = tmp_path / "water.lmp"
     input_file = tmp_path / "in.lammps"
@@ -331,12 +338,16 @@ def test_lammps_runs_six_atom_mace_model(tmp_path: Path) -> None:
 
 @pytest.mark.lammps
 @pytest.mark.mpi
-def test_lammps_mpi_matches_single_rank_six_atom_mace_model(tmp_path: Path) -> None:
-    """Run frozen MACE through DeePMD-kit with two MPI ranks."""
+@pytest.mark.parametrize("model_name", list(MODEL_INPUTS))
+def test_lammps_mpi_matches_single_rank_six_atom_gnn_model(
+    tmp_path: Path,
+    model_name: str,
+) -> None:
+    """Run a frozen GNN model through DeePMD-kit with two MPI ranks."""
     _ensure_lammps_available()
     _ensure_mpi_lammps_available()
     lammps_env = _lammps_env()
-    model_file = _freeze_mace_model(tmp_path)
+    model_file = _freeze_model(tmp_path, model_name)
 
     data_file = tmp_path / "water.lmp"
     single_input = tmp_path / "in.single.lammps"

--- a/tests/test_lammps.py
+++ b/tests/test_lammps.py
@@ -24,6 +24,10 @@ MODEL_INPUTS = {
     "mace": MACE_INPUT,
     "nequip": NEQUIP_INPUT,
 }
+MODEL_MPI_PE_ATOL = {
+    "mace": 1e-8,
+    "nequip": 5e-5,
+}
 SIX_ATOM_BOX = np.array([0.0, 13.0, 0.0, 13.0, 0.0, 13.0, 0.0, 0.0, 0.0])
 SIX_ATOM_COORD = np.array(
     [
@@ -365,6 +369,6 @@ def test_lammps_mpi_matches_single_rank_six_atom_gnn_model(
     np.testing.assert_allclose(
         _read_step_zero_pe(mpi_log),
         _read_step_zero_pe(single_log),
-        atol=1e-8,
+        atol=MODEL_MPI_PE_ATOL[model_name],
         rtol=0.0,
     )

--- a/tests/test_lammps.py
+++ b/tests/test_lammps.py
@@ -24,9 +24,9 @@ MODEL_INPUTS = {
     "mace": MACE_INPUT,
     "nequip": NEQUIP_INPUT,
 }
-MODEL_MPI_PE_ATOL = {
-    "mace": 1e-8,
-    "nequip": 5e-5,
+MODEL_MPI_PE_TOL = {
+    "mace": {"atol": 1e-8, "rtol": 0.0},
+    "nequip": {"atol": 1e-4, "rtol": 1e-6},
 }
 SIX_ATOM_BOX = np.array([0.0, 13.0, 0.0, 13.0, 0.0, 13.0, 0.0, 0.0, 0.0])
 SIX_ATOM_COORD = np.array(
@@ -369,6 +369,5 @@ def test_lammps_mpi_matches_single_rank_six_atom_gnn_model(
     np.testing.assert_allclose(
         _read_step_zero_pe(mpi_log),
         _read_step_zero_pe(single_log),
-        atol=MODEL_MPI_PE_ATOL[model_name],
-        rtol=0.0,
+        **MODEL_MPI_PE_TOL[model_name],
     )

--- a/tests/test_model.py
+++ b/tests/test_model.py
@@ -1180,9 +1180,9 @@ class TestNequipModel(unittest.TestCase, EnerModelTest, PTTestCase):  # type: ig
         with torch.jit.optimized_execution(should_optimize=False):
             cls._script_module = torch.jit.script(cls.module)
         cls.output_def = cls.module.translated_output_def()
-        cls.expected_has_message_passing = False
+        cls.expected_has_message_passing = True
         cls.expected_sel_type = []
         cls.expected_dim_fparam = 0
         cls.expected_dim_aparam = 0
-        cls.expected_nmpnn = 2
+        cls.expected_nmpnn = 1
         cls.supports_atomic_virial = True

--- a/tests/test_nequip_comm.py
+++ b/tests/test_nequip_comm.py
@@ -24,7 +24,7 @@ def _make_nequip_model() -> NequipModel:
 
 
 def _empty_comm_dict() -> dict[str, torch.Tensor]:
-    empty = torch.empty(0, dtype=torch.int64)
+    empty = torch.empty(0, dtype=torch.int32)
     return {
         "send_list": empty,
         "send_proc": empty,

--- a/tests/test_nequip_comm.py
+++ b/tests/test_nequip_comm.py
@@ -1,0 +1,121 @@
+"""Tests for NequIP layer-wise DeePMD communication."""
+
+import deepmd.pt.model  # noqa: F401
+import pytest
+import torch
+
+from deepmd_gnn.nequip import NequipModel
+
+
+def _make_nequip_model() -> NequipModel:
+    old_default_dtype = torch.get_default_dtype()
+    torch.set_default_dtype(torch.float64)
+    try:
+        torch.manual_seed(20240824)
+        return NequipModel(
+            type_map=["O", "H"],
+            sel=4,
+            r_max=5.0,
+            num_layers=2,
+            precision="float64",
+        )
+    finally:
+        torch.set_default_dtype(old_default_dtype)
+
+
+def _empty_comm_dict() -> dict[str, torch.Tensor]:
+    empty = torch.empty(0, dtype=torch.int64)
+    return {
+        "send_list": empty,
+        "send_proc": empty,
+        "recv_proc": empty,
+        "send_num": empty,
+        "recv_num": empty,
+        "communicator": empty,
+    }
+
+
+def test_nequip_comm_branch_matches_regular_lower_without_ghosts(monkeypatch) -> None:
+    """Identity communication should reproduce the regular lower path."""
+
+    def fake_border_op(
+        send_list: torch.Tensor,
+        send_proc: torch.Tensor,
+        recv_proc: torch.Tensor,
+        send_num: torch.Tensor,
+        recv_num: torch.Tensor,
+        node_feats: torch.Tensor,
+        communicator: torch.Tensor,
+        nloc: torch.Tensor,
+        nghost: torch.Tensor,
+    ) -> tuple[torch.Tensor]:
+        _ = (
+            send_list,
+            send_proc,
+            recv_proc,
+            send_num,
+            recv_num,
+            communicator,
+            nloc,
+            nghost,
+        )
+        return (node_feats,)
+
+    monkeypatch.setattr(torch.ops.deepmd, "border_op", fake_border_op, raising=False)
+
+    model = _make_nequip_model()
+    device = next(model.parameters()).device
+    coord = torch.tensor(
+        [[[0.0, 0.0, 0.0], [1.0, 0.0, 0.0], [0.0, 1.0, 0.0]]],
+        dtype=torch.float64,
+        device=device,
+    )
+    atype = torch.tensor([[0, 1, 1]], dtype=torch.int64, device=device)
+    nlist = torch.tensor(
+        [[[1, 2, -1, -1], [0, 2, -1, -1], [0, 1, -1, -1]]],
+        dtype=torch.int64,
+        device=device,
+    )
+
+    regular = model.forward_lower(coord, atype, nlist)
+    communicated = model.forward_lower(
+        coord,
+        atype,
+        nlist,
+        comm_dict=_empty_comm_dict(),
+    )
+
+    for key in ["atom_energy", "energy", "extended_force", "virial"]:
+        torch.testing.assert_close(
+            communicated[key],
+            regular[key],
+            atol=1e-6,
+            rtol=0.0,
+        )
+
+
+def test_nequip_lower_with_ghosts_requires_comm_or_mapping() -> None:
+    """Ghost lower inference should not rebuild a multi-hop NequIP nlist."""
+    model = _make_nequip_model()
+    device = next(model.parameters()).device
+    coord = torch.tensor(
+        [
+            [
+                [0.0, 0.0, 0.0],
+                [1.0, 0.0, 0.0],
+                [0.0, 1.0, 0.0],
+                [2.0, 0.0, 0.0],
+            ],
+        ],
+        dtype=torch.float64,
+        device=device,
+    )
+    atype = torch.tensor([[0, 1, 1, 1]], dtype=torch.int64, device=device)
+    nlist = torch.tensor(
+        [[[1, 2, -1, -1], [0, 2, -1, -1], [0, 1, -1, -1]]],
+        dtype=torch.int64,
+        device=device,
+    )
+
+    with pytest.raises(ValueError, match="requires either comm_dict"):
+        model.forward_lower(coord, atype, nlist)


### PR DESCRIPTION
## Summary
- add layer-wise DeePMD border_op communication modules to NequIP graph models
- advertise NequIP message passing with r_max cutoff and require comm_dict or mapping for ghost lower inference
- update docs and add NequIP comm/LAMMPS coverage, including a real NequIP test config

## Tests
- ruff check tests/test_lammps.py tests/test_nequip_comm.py deepmd_gnn/nequip.py tests/test_model.py tests/test_training.py
- python -m compileall deepmd_gnn tests
- python -m pytest tests/test_lammps.py --collect-only -q
- python -m pytest tests/test_nequip_comm.py tests/test_model.py::TestNequipModel -q

Note: local pytest commands that import deepmd.pt were run with a temporary process-local stub for the stale installed deepmd-gnn entry point (deepmd_gnn.pt:load).