### PR TITLE
feat: add optional MACE cuEquivariance training

### DIFF
--- a/README.md
+++ b/README.md
@@ -110,7 +110,17 @@ same way as other DeePMD-kit frozen models.
 
 MACE training can use cuEquivariance kernels when the installed MACE package
 provides `CuEquivarianceConfig` and the cuEquivariance runtime packages are
-available. Enable it in the `model` section:
+available. Install the matching extra for the CUDA runtime used by PyTorch:
+
+```sh
+pip install "deepmd-gnn[cueq]"
+```
+
+The `cueq` extra installs the CUDA 12 cuEquivariance op package. For CUDA 11
+environments, use `deepmd-gnn[cueq-cu11]` instead. When installing from a
+source checkout, use `pip install ".[cueq]"` or `pip install ".[cueq-cu11]"`.
+
+Then enable it in the `model` section:
 
 ```json
 "model": {

--- a/README.md
+++ b/README.md
@@ -106,6 +106,43 @@ models include the extra communication artifact needed by LAMMPS/MPI inside the
 exported `.pt2` package, so the resulting file can be passed to LAMMPS in the
 same way as other DeePMD-kit frozen models.
 
+#### Training MACE with cuEquivariance
+
+MACE training can use cuEquivariance kernels when the installed MACE package
+provides `CuEquivarianceConfig` and the cuEquivariance runtime packages are
+available. Enable it in the `model` section:
+
+```json
+"model": {
+  "type": "mace",
+  "enable_cueq": true
+}
+```
+
+Then train with either PyTorch backend:
+
+```sh
+dp --pt train input.json
+dp --pt-expt train input.json
+```
+
+On a single RTX 5090, using the water example data with `sel = "auto"`,
+`hidden_irreps = "128x0e + 128x1o"`, `batch_size = 1`, and
+`disp_freq = 100`, 2000-step runs were used to sample steady-state training
+speed:
+
+| backend        | cuEquivariance | steady avg after step 300 | speedup |
+| -------------- | -------------: | ------------------------: | ------: |
+| `dp --pt`      |             no |             0.1955 s/step |   1.00x |
+| `dp --pt`      |            yes |             0.1061 s/step |   1.84x |
+| `dp --pt-expt` |             no |             0.2025 s/step |   1.00x |
+| `dp --pt-expt` |            yes |             0.1007 s/step |   2.01x |
+
+The cuEquivariance effect is similar in both backends, but not bit-for-bit
+identical: in this run, the steady cuEquivariance speed differed by about 5%.
+The first cuEquivariance step includes a one-time kernel initialization cost
+(about 56 s in this run), which is amortized over long training jobs.
+
 #### Training MACE with `torch.compile`
 
 MACE training through the `pt_expt` backend can use DeePMD-kit's native
@@ -135,6 +172,11 @@ speed:
 
 The first compiled step includes a one-time Inductor trace/compile cost
 (97.17 s in this run), which is amortized over normal long training jobs.
+
+Do not enable `enable_cueq` and `enable_compile` together for now. With
+cuEquivariance enabled, DeePMD-kit's symbolic `make_fx` compile trace fails in
+the cuEquivariance `uniform_1d` fake-tensor path with a data-dependent symbolic
+shape guard.
 
 ### Running LAMMPS + GNN models with period boundary conditions
 
@@ -190,7 +232,8 @@ Below is default values for the MACE model, most of which follows default values
   "radial_type": "bessel",
   "radial_MLP": [64, 64, 64],
   "std": 1.0,
-  "precision": "float32"
+  "precision": "float32",
+  "enable_cueq": false
 }
 ```
 

--- a/README.md
+++ b/README.md
@@ -143,6 +143,12 @@ identical: in this run, the steady cuEquivariance speed differed by about 5%.
 The first cuEquivariance step includes a one-time kernel initialization cost
 (about 56 s in this run), which is amortized over long training jobs.
 
+cuEquivariance is currently supported for training only. Freezing a
+cuEquivariance checkpoint does not work in either backend: `dp --pt freeze`
+fails while TorchScript scripts the cuEquivariance `SegmentedPolynomial`, and
+`dp --pt-expt freeze` fails while symbolic `make_fx` traces the cuEquivariance
+`uniform_1d` fake-tensor path.
+
 #### Training MACE with `torch.compile`
 
 MACE training through the `pt_expt` backend can use DeePMD-kit's native

--- a/README.md
+++ b/README.md
@@ -143,11 +143,11 @@ identical: in this run, the steady cuEquivariance speed differed by about 5%.
 The first cuEquivariance step includes a one-time kernel initialization cost
 (about 56 s in this run), which is amortized over long training jobs.
 
-cuEquivariance is currently supported for training only. Freezing a
-cuEquivariance checkpoint does not work in either backend: `dp --pt freeze`
-fails while TorchScript scripts the cuEquivariance `SegmentedPolynomial`, and
-`dp --pt-expt freeze` fails while symbolic `make_fx` traces the cuEquivariance
-`uniform_1d` fake-tensor path.
+cuEquivariance accelerates training only. When freezing a checkpoint whose
+input had `"enable_cueq": true`, deepmd-gnn disables cuEquivariance for the
+frozen model and converts the MACE weights back to the e3nn format. This lets
+both `dp --pt freeze` and `dp --pt-expt freeze` export normally, but the frozen
+model does not use cuEquivariance kernels.
 
 #### Training MACE with `torch.compile`
 

--- a/deepmd_gnn/argcheck.py
+++ b/deepmd_gnn/argcheck.py
@@ -29,6 +29,7 @@ def mace_model_args() -> Argument:
     doc_radial_mlp = "width of the radial MLP"
     doc_std = "Standard deviation of force components in the training set"
     doc_precision = "Precision of the model, float32 or float64"
+    doc_enable_cueq = "Enable cuEquivariance acceleration for MACE training"
     return Argument(
         "mace",
         dict,
@@ -115,6 +116,13 @@ def mace_model_args() -> Argument:
                 optional=True,
                 default="float32",
                 doc=doc_precision,
+            ),
+            Argument(
+                "enable_cueq",
+                bool,
+                optional=True,
+                default=False,
+                doc=doc_enable_cueq,
             ),
         ],
         doc="MACE model",

--- a/deepmd_gnn/edge.py
+++ b/deepmd_gnn/edge.py
@@ -9,22 +9,24 @@ def _mm_tensor(mm_types: list[int]) -> torch.Tensor:
     return torch.tensor(mm_types, dtype=torch.int64, device="cpu")
 
 
-@torch.library.register_fake("deepmd_gnn::dense_edge_index")
-def _fake_dense_edge_index(
-    nlist: torch.Tensor,
-    _atype: torch.Tensor,
-    _mm: torch.Tensor,
-) -> tuple[torch.Tensor, torch.Tensor]:
-    if nlist.dim() == 2:
-        dense_edge_size = nlist.shape[0] * nlist.shape[1]
-    elif nlist.dim() == 3:
-        dense_edge_size = nlist.shape[0] * nlist.shape[1] * nlist.shape[2]
-    else:
-        msg = "nlist must be 2D or 3D"
-        raise ValueError(msg)
-    edge_index = nlist.new_empty((dense_edge_size, 2), dtype=torch.int64)
-    edge_mask = nlist.new_empty((dense_edge_size,), dtype=torch.bool)
-    return edge_index, edge_mask
+if hasattr(torch.ops.deepmd_gnn, "dense_edge_index"):
+
+    @torch.library.register_fake("deepmd_gnn::dense_edge_index")
+    def _fake_dense_edge_index(
+        nlist: torch.Tensor,
+        _atype: torch.Tensor,
+        _mm: torch.Tensor,
+    ) -> tuple[torch.Tensor, torch.Tensor]:
+        if nlist.dim() == 2:
+            dense_edge_size = nlist.shape[0] * nlist.shape[1]
+        elif nlist.dim() == 3:
+            dense_edge_size = nlist.shape[0] * nlist.shape[1] * nlist.shape[2]
+        else:
+            msg = "nlist must be 2D or 3D"
+            raise ValueError(msg)
+        edge_index = nlist.new_empty((dense_edge_size, 2), dtype=torch.int64)
+        edge_mask = nlist.new_empty((dense_edge_size,), dtype=torch.bool)
+        return edge_index, edge_mask
 
 
 def dense_edge_index(

--- a/deepmd_gnn/mace.py
+++ b/deepmd_gnn/mace.py
@@ -3,6 +3,7 @@
 
 import importlib
 import json
+import warnings
 from copy import deepcopy
 from typing import Any, Optional
 
@@ -69,6 +70,32 @@ def _pad_nlist_for_export(nlist: torch.Tensor) -> torch.Tensor:
         device=nlist.device,
     )
     return torch.cat([nlist, pad], dim=-1)
+
+
+def _make_cueq_config(enable_cueq: bool) -> Any | None:  # noqa: ANN401
+    """Build the MACE cuEquivariance config when requested."""
+    if not enable_cueq:
+        return None
+    wrapper_ops = importlib.import_module("mace.modules.wrapper_ops")
+    config_cls = getattr(wrapper_ops, "CuEquivarianceConfig", None)
+    if config_cls is None:
+        msg = "enable_cueq=True requires a MACE version with CuEquivarianceConfig"
+        raise RuntimeError(msg)
+    device_type = getattr(env.DEVICE, "type", str(env.DEVICE))
+    config = config_cls(
+        enabled=True,
+        layout="ir_mul",
+        group="O3_e3nn",
+        optimize_all=True,
+        conv_fusion=(device_type == "cuda"),
+    )
+    if not getattr(config, "enabled", False):
+        msg = (
+            "enable_cueq=True requires cuequivariance, cuequivariance-torch, "
+            "and cuequivariance-ops-torch-cu12/cu11 to be installed"
+        )
+        raise RuntimeError(msg)
+    return config
 
 
 if not hasattr(torch.ops.deepmd, "border_op"):  # pragma: no cover
@@ -279,6 +306,7 @@ def _make_mace_network(
     std: float,
     radial_MLP: list[int],
     radial_type: str,
+    enable_cueq: bool,
     script_model: bool,
 ) -> torch.nn.Module:
     optimization_defaults = None
@@ -308,12 +336,22 @@ def _make_mace_network(
             atomic_inter_shift=0.0,
             radial_MLP=radial_MLP,
             radial_type=radial_type,
+            cueq_config=_make_cueq_config(enable_cueq),
         ).to(env.DEVICE)
     finally:
         if optimization_defaults is not None:
             e3nn.set_optimization_defaults(**optimization_defaults)
     if script_model:
-        return script(model)
+        try:
+            return script(model)
+        except Exception as exc:
+            if not enable_cueq:
+                raise
+            warnings.warn(
+                "Falling back to eager MACE submodel because cuEquivariance "
+                f"could not be scripted: {exc}",
+                stacklevel=2,
+            )
     return model
 
 
@@ -425,6 +463,7 @@ class MaceModel(BaseModel):
         radial_MLP: list[int] = [64, 64, 64],  # noqa: B006
         std: float = 1,
         avg_num_neighbors: float | None = None,
+        enable_cueq: bool = False,
         **kwargs: Any,  # noqa: ANN401
     ) -> None:
         super().__init__(**kwargs)
@@ -447,6 +486,7 @@ class MaceModel(BaseModel):
             "radial_MLP": radial_MLP,
             "std": std,
             "avg_num_neighbors": avg_num_neighbors,
+            "enable_cueq": enable_cueq,
         }
         self.type_map = type_map
         self.ntypes = len(type_map)
@@ -487,6 +527,7 @@ class MaceModel(BaseModel):
             std=std,
             radial_MLP=radial_MLP,
             radial_type=radial_type,
+            enable_cueq=enable_cueq,
             script_model=True,
         )
         self.atomic_numbers = atomic_numbers
@@ -1279,6 +1320,7 @@ class MaceModel(BaseModel):
             std=self.params["std"],
             radial_MLP=self.params["radial_MLP"],
             radial_type=self.params["radial_type"],
+            enable_cueq=self.params["enable_cueq"],
             script_model=False,
         )
         raw_model.load_state_dict(scripted_model.state_dict())

--- a/deepmd_gnn/mace.py
+++ b/deepmd_gnn/mace.py
@@ -631,6 +631,7 @@ class MaceModel(BaseModel):
             std=self.params["std"],
             radial_MLP=self.params["radial_MLP"],
             radial_type=self.params["radial_type"],
+            enable_cueq=self.params["enable_cueq"],
             script_model=False,
         )
         raw_model.load_state_dict(scripted_model.state_dict())
@@ -1589,6 +1590,7 @@ class MaceModel(BaseModel):
             std=self.params["std"],
             radial_MLP=self.params["radial_MLP"],
             radial_type=self.params["radial_type"],
+            enable_cueq=self.params["enable_cueq"],
             script_model=False,
         )
         raw_model.load_state_dict(scripted_model.state_dict())

--- a/deepmd_gnn/mace.py
+++ b/deepmd_gnn/mace.py
@@ -3,7 +3,9 @@
 
 import importlib
 import json
+import sys
 import warnings
+from collections.abc import MutableMapping
 from copy import deepcopy
 from typing import Any, Optional, cast
 
@@ -96,6 +98,50 @@ def _make_cueq_config(enable_cueq: bool) -> Any | None:  # noqa: ANN401
         )
         raise RuntimeError(msg)
     return config
+
+
+def _is_freeze_command() -> bool:
+    """Return whether the current process is running a DeePMD freeze command."""
+    return "freeze" in sys.argv[1:]
+
+
+def _disable_cueq_in_model_params(model_params: MutableMapping[str, Any]) -> bool:
+    """Disable MACE cuEquivariance flags in model definition metadata."""
+    changed = False
+    if model_params.get("type") == "mace" and model_params.get("enable_cueq"):
+        model_params["enable_cueq"] = False
+        changed = True
+    model_dict = model_params.get("model_dict")
+    if isinstance(model_dict, MutableMapping):
+        for sub_model_params in model_dict.values():
+            if isinstance(sub_model_params, MutableMapping):
+                changed |= _disable_cueq_in_model_params(sub_model_params)
+    return changed
+
+
+def _transfer_cueq_to_e3nn(
+    source_model: torch.nn.Module,
+    target_model: torch.nn.Module,
+    *,
+    hidden_irreps: str,
+    correlation: int,
+    num_interactions: int,
+) -> None:
+    """Transfer MACE cuEquivariance weights to an e3nn MACE model."""
+    from mace.cli.convert_cueq_e3nn import (  # noqa: PLC0415
+        transfer_weights,
+    )
+
+    num_product_irreps = len(o3.Irreps(hidden_irreps).slices()) - 1
+    use_reduced_cg = bool(getattr(source_model, "use_reduced_cg", True))
+    transfer_weights(
+        source_model,
+        target_model,
+        num_product_irreps,
+        correlation,
+        num_interactions,
+        use_reduced_cg,
+    )
 
 
 if not hasattr(torch.ops.deepmd, "border_op"):  # pragma: no cover
@@ -536,6 +582,7 @@ class MaceModel(BaseModel):
             "avg_num_neighbors": avg_num_neighbors,
             "enable_cueq": enable_cueq,
         }
+        self._disable_cueq_for_freeze = bool(enable_cueq and _is_freeze_command())
         self.type_map = type_map
         self.ntypes = len(type_map)
         self.rcut = r_max
@@ -575,10 +622,149 @@ class MaceModel(BaseModel):
             std=std,
             radial_MLP=radial_MLP,
             radial_type=radial_type,
-            enable_cueq=enable_cueq,
-            script_model=True,
+            enable_cueq=enable_cueq and not self._disable_cueq_for_freeze,
+            script_model=not self._disable_cueq_for_freeze,
         )
         self.atomic_numbers = atomic_numbers
+
+    def _enable_cueq_for_runtime(self) -> bool:
+        return bool(self.params["enable_cueq"] and not self._disable_cueq_for_freeze)
+
+    def _params_for_serialization(self) -> dict[str, Any]:
+        params = self.params.copy()
+        if self._disable_cueq_for_freeze:
+            params["enable_cueq"] = False
+        return params
+
+    def _sync_freeze_model_def_script(self) -> None:
+        model_def_script = cast("str", getattr(self, "model_def_script", ""))
+        if not self._disable_cueq_for_freeze or not model_def_script:
+            return
+        try:
+            model_params = json.loads(model_def_script)
+        except json.JSONDecodeError:
+            return
+        if _disable_cueq_in_model_params(model_params):
+            self.model_def_script = json.dumps(model_params)
+
+    def _make_mace_network_from_params(
+        self,
+        *,
+        enable_cueq: bool,
+        script_model: bool,
+    ) -> torch.nn.Module:
+        return _make_mace_network(
+            r_max=self.params["r_max"],
+            num_radial_basis=self.params["num_radial_basis"],
+            num_cutoff_basis=self.params["num_cutoff_basis"],
+            max_ell=self.params["max_ell"],
+            interaction=self.params["interaction"],
+            num_interactions=self.params["num_interactions"],
+            num_elements=self.ntypes,
+            hidden_irreps=self.params["hidden_irreps"],
+            atomic_numbers=self.atomic_numbers,
+            avg_num_neighbors=self.avg_num_neighbors,
+            pair_repulsion=self.params["pair_repulsion"],
+            distance_transform=self.params["distance_transform"],
+            correlation=self.params["correlation"],
+            gate=self.params["gate"],
+            MLP_irreps=self.params["MLP_irreps"],
+            std=self.params["std"],
+            radial_MLP=self.params["radial_MLP"],
+            radial_type=self.params["radial_type"],
+            enable_cueq=enable_cueq,
+            script_model=script_model,
+        )
+
+    def _make_raw_mace_network_from_current_state(self) -> torch.nn.Module:
+        model = cast("torch.nn.Module", self.model)
+        raw_model = self._make_mace_network_from_params(
+            enable_cueq=self._enable_cueq_for_runtime(),
+            script_model=False,
+        )
+        raw_model.load_state_dict(model.state_dict())
+        return raw_model
+
+    def _replace_with_scripted_e3nn_model_for_freeze(
+        self,
+        raw_model: torch.nn.Module | None = None,
+    ) -> torch.nn.Module:
+        scripted_model = self._make_mace_network_from_params(
+            enable_cueq=False,
+            script_model=True,
+        )
+        if raw_model is not None:
+            scripted_model.load_state_dict(raw_model.state_dict())
+        self.model = scripted_model
+        return scripted_model
+
+    def _adapt_cueq_state_for_freeze(
+        self,
+        state_dict: MutableMapping[str, Any],
+        prefix: str,
+    ) -> None:
+        if not self._disable_cueq_for_freeze:
+            return
+        self._sync_freeze_model_def_script()
+        extra_state = state_dict.get("_extra_state")
+        if isinstance(extra_state, MutableMapping):
+            model_params = extra_state.get("model_params")
+            if isinstance(model_params, MutableMapping):
+                _disable_cueq_in_model_params(model_params)
+
+        model_prefix = f"{prefix}model."
+        source_state = {
+            key.removeprefix(model_prefix): value
+            for key, value in state_dict.items()
+            if key.startswith(model_prefix)
+        }
+        if "products.0.symmetric_contractions.weight" not in source_state:
+            self._replace_with_scripted_e3nn_model_for_freeze()
+            return
+
+        source_model = self._make_mace_network_from_params(
+            enable_cueq=True,
+            script_model=False,
+        )
+        source_model.load_state_dict(source_state)
+        target_model = cast("torch.nn.Module", self.model)
+        _transfer_cueq_to_e3nn(
+            source_model,
+            target_model,
+            hidden_irreps=self.params["hidden_irreps"],
+            correlation=self.params["correlation"],
+            num_interactions=self.params["num_interactions"],
+        )
+        scripted_model = self._replace_with_scripted_e3nn_model_for_freeze(
+            target_model,
+        )
+
+        for key in list(state_dict):
+            if key.startswith(model_prefix):
+                del state_dict[key]
+        for key, value in scripted_model.state_dict().items():
+            state_dict[f"{model_prefix}{key}"] = value
+
+    def _load_from_state_dict(
+        self,
+        state_dict: MutableMapping[str, Any],
+        prefix: str,
+        local_metadata: MutableMapping[str, Any],
+        strict: bool,
+        missing_keys: list[str],
+        unexpected_keys: list[str],
+        error_msgs: list[str],
+    ) -> None:
+        self._adapt_cueq_state_for_freeze(state_dict, prefix)
+        super()._load_from_state_dict(
+            state_dict,
+            prefix,
+            local_metadata,
+            strict,
+            missing_keys,
+            unexpected_keys,
+            error_msgs,
+        )
 
     @property
     def atomic_model(self) -> Any:  # noqa: ANN401
@@ -612,29 +798,7 @@ class MaceModel(BaseModel):
             cached.train(self.training)
             return cached
 
-        raw_model = _make_mace_network(
-            r_max=self.params["r_max"],
-            num_radial_basis=self.params["num_radial_basis"],
-            num_cutoff_basis=self.params["num_cutoff_basis"],
-            max_ell=self.params["max_ell"],
-            interaction=self.params["interaction"],
-            num_interactions=self.params["num_interactions"],
-            num_elements=self.ntypes,
-            hidden_irreps=self.params["hidden_irreps"],
-            atomic_numbers=self.atomic_numbers,
-            avg_num_neighbors=self.avg_num_neighbors,
-            pair_repulsion=self.params["pair_repulsion"],
-            distance_transform=self.params["distance_transform"],
-            correlation=self.params["correlation"],
-            gate=self.params["gate"],
-            MLP_irreps=self.params["MLP_irreps"],
-            std=self.params["std"],
-            radial_MLP=self.params["radial_MLP"],
-            radial_type=self.params["radial_type"],
-            enable_cueq=self.params["enable_cueq"],
-            script_model=False,
-        )
-        raw_model.load_state_dict(scripted_model.state_dict())
+        raw_model = self._make_raw_mace_network_from_current_state()
         _link_module_state(raw_model, scripted_model)
         raw_model.train(self.training)
         self.__dict__["_compile_trace_model"] = raw_model
@@ -1479,29 +1643,7 @@ class MaceModel(BaseModel):
         make_fx_kwargs = make_fx_kwargs.copy()
         model = self
         scripted_model = self.model
-        raw_model = _make_mace_network(
-            r_max=self.params["r_max"],
-            num_radial_basis=self.params["num_radial_basis"],
-            num_cutoff_basis=self.params["num_cutoff_basis"],
-            max_ell=self.params["max_ell"],
-            interaction=self.params["interaction"],
-            num_interactions=self.params["num_interactions"],
-            num_elements=self.ntypes,
-            hidden_irreps=self.params["hidden_irreps"],
-            atomic_numbers=self.atomic_numbers,
-            avg_num_neighbors=self.avg_num_neighbors,
-            pair_repulsion=self.params["pair_repulsion"],
-            distance_transform=self.params["distance_transform"],
-            correlation=self.params["correlation"],
-            gate=self.params["gate"],
-            MLP_irreps=self.params["MLP_irreps"],
-            std=self.params["std"],
-            radial_MLP=self.params["radial_MLP"],
-            radial_type=self.params["radial_type"],
-            enable_cueq=self.params["enable_cueq"],
-            script_model=False,
-        )
-        raw_model.load_state_dict(scripted_model.state_dict())
+        raw_model = self._make_raw_mace_network_from_current_state()
         raw_model.to(extended_coord.device)
         raw_model.train(scripted_model.training)
 
@@ -1571,29 +1713,7 @@ class MaceModel(BaseModel):
         make_fx_kwargs = make_fx_kwargs.copy()
         model = self
         scripted_model = self.model
-        raw_model = _make_mace_network(
-            r_max=self.params["r_max"],
-            num_radial_basis=self.params["num_radial_basis"],
-            num_cutoff_basis=self.params["num_cutoff_basis"],
-            max_ell=self.params["max_ell"],
-            interaction=self.params["interaction"],
-            num_interactions=self.params["num_interactions"],
-            num_elements=self.ntypes,
-            hidden_irreps=self.params["hidden_irreps"],
-            atomic_numbers=self.atomic_numbers,
-            avg_num_neighbors=self.avg_num_neighbors,
-            pair_repulsion=self.params["pair_repulsion"],
-            distance_transform=self.params["distance_transform"],
-            correlation=self.params["correlation"],
-            gate=self.params["gate"],
-            MLP_irreps=self.params["MLP_irreps"],
-            std=self.params["std"],
-            radial_MLP=self.params["radial_MLP"],
-            radial_type=self.params["radial_type"],
-            enable_cueq=self.params["enable_cueq"],
-            script_model=False,
-        )
-        raw_model.load_state_dict(scripted_model.state_dict())
+        raw_model = self._make_raw_mace_network_from_current_state()
         raw_model.to(extended_coord.device)
         raw_model.train(scripted_model.training)
 
@@ -1837,7 +1957,7 @@ class MaceModel(BaseModel):
             "@class": "Model",
             "@version": 1,
             "type": "mace",
-            **self.params,
+            **self._params_for_serialization(),
             "@variables": {
                 kk: to_numpy_array(vv) for kk, vv in self.model.state_dict().items()
             },
@@ -1944,6 +2064,7 @@ class MaceModel(BaseModel):
         BaseBaseModel
             The model
         """
+        original_model_params = model_params
         model_params_old = model_params.copy()
         model_params = model_params.copy()
         model_params.pop("type", None)
@@ -1956,5 +2077,9 @@ class MaceModel(BaseModel):
             msg = f"precision {precision} not supported"
             raise ValueError(msg)
         model = cls(**model_params)
+        if model._disable_cueq_for_freeze:
+            model_params_old["enable_cueq"] = False
+            if isinstance(original_model_params, MutableMapping):
+                original_model_params["enable_cueq"] = False
         model.model_def_script = json.dumps(model_params_old)
         return model

--- a/deepmd_gnn/mace.py
+++ b/deepmd_gnn/mace.py
@@ -94,7 +94,9 @@ def _make_cueq_config(enable_cueq: bool) -> Any | None:  # noqa: ANN401
     if not getattr(config, "enabled", False):
         msg = (
             "enable_cueq=True requires cuequivariance, cuequivariance-torch, "
-            "and cuequivariance-ops-torch-cu12/cu11 to be installed"
+            "and cuequivariance-ops-torch-cu12/cu11 to be installed. "
+            "Install deepmd-gnn[cueq] for CUDA 12 or deepmd-gnn[cueq-cu11] "
+            "for CUDA 11."
         )
         raise RuntimeError(msg)
     return config

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -51,6 +51,21 @@ mace = "deepmd_gnn.pt_expt:load"
 repository = "https://gitlab.com/RutgersLBSR/deepmd-gnn"
 
 [project.optional-dependencies]
+cueq = [
+    "cuequivariance>=0.10.0",
+    "cuequivariance-torch>=0.10.0",
+    "cuequivariance-ops-torch-cu12>=0.10.0",
+]
+cueq-cu11 = [
+    "cuequivariance>=0.10.0",
+    "cuequivariance-torch>=0.10.0",
+    "cuequivariance-ops-torch-cu11>=0.10.0",
+]
+cueq-cu12 = [
+    "cuequivariance>=0.10.0",
+    "cuequivariance-torch>=0.10.0",
+    "cuequivariance-ops-torch-cu12>=0.10.0",
+]
 test = [
     'pytest',
     'pytest-cov',

--- a/tests/test_pt_expt.py
+++ b/tests/test_pt_expt.py
@@ -1,6 +1,7 @@
 # SPDX-License-Identifier: LGPL-3.0-or-later
 """Tests for DeePMD-kit's PyTorch exportable backend integration."""
 
+import json
 import sys
 import types
 
@@ -55,6 +56,25 @@ def test_mace_export_metadata_defaults() -> None:
     assert model.has_chg_spin_ebd() is False
     assert model.has_default_chg_spin() is False
     assert model.get_default_chg_spin() is None
+
+
+def test_mace_freeze_disables_cueq_metadata(monkeypatch) -> None:
+    """Freeze-time MACE construction exports e3nn metadata for cueq checkpoints."""
+    monkeypatch.setattr(sys, "argv", ["dp", "--pt-expt", "freeze"])
+    model_params = {
+        "type": "mace",
+        "type_map": ["O", "H"],
+        "r_max": 6.0,
+        "sel": 4,
+        "hidden_irreps": "16x0e",
+        "enable_cueq": True,
+    }
+
+    model = MaceModel.get_model(model_params)
+
+    assert model_params["enable_cueq"] is False
+    assert json.loads(model.get_model_def_script())["enable_cueq"] is False
+    assert model.serialize()["enable_cueq"] is False
 
 
 def test_mace_pt_expt_reports_with_comm_artifact_requirement() -> None:


### PR DESCRIPTION
## Summary

- add an optional `enable_cueq` MACE model parameter
- pass MACE's `CuEquivarianceConfig` into `ScaleShiftMACE` when requested
- fall back to eager MACE if cuEquivariance modules cannot be scripted
- guard `dense_edge_index` fake registration when running source Python against an older installed OP library

## Benchmark

Installed cuEquivariance packages:

- `cuequivariance==0.10.0`
- `cuequivariance-torch==0.10.0`
- `cuequivariance-ops-torch-cu12==0.10.0`

Command shape:

```sh
srun --gres=gpu:1 dp --pt train input.json
```

Environment:

- GPU: NVIDIA GeForce RTX 5090
- PyTorch: 2.10.0+cu128
- DeePMD-kit: 3.1.3
- MACE: 0.3.15
- model: 0.203M parameters, 192 atoms/frame, 100 training steps

Results:

| Mode | Total real time | DeePMD average training time |
| --- | ---: | ---: |
| e3nn baseline | 34.59 s | 0.1128 s/batch |
| cuEquivariance | 60.03 s | 0.1012 s/batch |

The stable training throughput improves by about 10%, but total wall time is worse for this short job because the first cuEquivariance batch takes about 30 s for initialization/compilation.

## Notes

With MACE 0.3.15 and cuEquivariance 0.10.0, the cuEquivariance MACE submodel does not script cleanly due to the conv-fusion wrapper (`SegmentedPolynomial.original_forward`). This PR keeps training usable by falling back to eager mode when `enable_cueq` is true. This does not imply frozen TorchScript inference support.

## Tests

- `python -m ruff check deepmd_gnn/mace.py deepmd_gnn/argcheck.py deepmd_gnn/edge.py`
- default MACE construction smoke test
- `srun --gres=gpu:1 dp --pt train input.json` for baseline and `enable_cueq=true`

Known local test limitations:

- `tests/test_pt_expt.py` does not collect with local `deepmd-kit==3.1.3` because `_needs_with_comm_artifact` is unavailable.
- `tests/test_mace_comm.py` has one dtype assertion failure unrelated to the cuEquivariance path.
