### PR TITLE
fix: avoid forcing torch CUDA link for CUDA ops

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -68,9 +68,6 @@ if(DEEPMD_GNN_ENABLE_CUDA)
       CACHE BOOL
             "Bypass PyTorch CUDA toolkit discovery when nvcc is unavailable"
             FORCE)
-  set(DEEPMD_GNN_LINK_TORCH_CUDA
-      ON
-      CACHE BOOL "Link the OP against PyTorch CUDA libraries" FORCE)
   if(NOT DEFINED CMAKE_CUDA_COMPILER)
     set(CMAKE_CUDA_COMPILER ${DEEPMD_GNN_NVCC_EXECUTABLE})
   endif()


### PR DESCRIPTION
## Summary
- stop forcing `DEEPMD_GNN_LINK_TORCH_CUDA=ON` when CUDA ops are enabled
- keep the default CUDA op link path on the PyTorch CPU runtime unless explicitly requested
- avoid unnecessary dynamic dependencies on `libtorch_cuda.so`, `libc10_cuda.so`, and `libcudart.so.12`

## Verification
- configured and built with CUDA ops enabled using local `torch 2.10.0+cu128`
- confirmed CMake logs `Linking deepmd-gnn OP against PyTorch CPU runtime`
- confirmed `readelf -d libdeepmd_gnn.so` has no `libtorch_cuda.so`, `libc10_cuda.so`, or dynamic `libcudart.so.12`
- loaded the built op and ran CPU `edge_index` with `torch.cuda.is_available() == False`