### PR TITLE
feat: dynamically load CUDA runtime for ops

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+third_party/implib/** linguist-vendored -diff

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,5 +1,6 @@
 # See https://pre-commit.com for more information
 # See https://pre-commit.com/hooks.html for more hooks
+exclude: ^third_party/implib/
 repos:
   - repo: https://github.com/pre-commit/pre-commit-hooks
     rev: v6.0.0

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -22,6 +22,8 @@ option(DEEPMD_GNN_BYPASS_TORCH_CUDA_CHECK
        "Bypass PyTorch CUDA toolkit discovery when nvcc is unavailable" ON)
 option(DEEPMD_GNN_LINK_TORCH_CUDA "Link the OP against PyTorch CUDA libraries"
        OFF)
+option(DEEPMD_GNN_DYNAMIC_CUDART
+       "Dynamically load the CUDA runtime library for CUDA OPs" ON)
 
 if((NOT BUILD_PY_IF) AND (NOT BUILD_CPP_IF))
   # nothing to do

--- a/op/CMakeLists.txt
+++ b/op/CMakeLists.txt
@@ -2,6 +2,16 @@ set(OP_SRC edge_index.cc)
 
 if(DEEPMD_GNN_ENABLE_CUDA)
   list(APPEND OP_SRC edge_index_cuda.cu)
+  if(DEEPMD_GNN_DYNAMIC_CUDART)
+    if(UNIX AND NOT APPLE)
+      add_subdirectory(cudart)
+    else()
+      message(
+        WARNING
+          "DEEPMD_GNN_DYNAMIC_CUDART is only supported on non-Apple UNIX platforms"
+      )
+    endif()
+  endif()
 endif()
 
 add_library(deepmd_gnn MODULE ${OP_SRC})
@@ -14,6 +24,10 @@ endif()
 if(DEEPMD_GNN_ENABLE_CUDA)
   target_compile_definitions(deepmd_gnn PRIVATE DEEPMD_GNN_WITH_CUDA)
   set_target_properties(deepmd_gnn PROPERTIES CUDA_STANDARD 17)
+  if(TARGET deepmd_gnn_cudart)
+    set_target_properties(deepmd_gnn PROPERTIES CUDA_RUNTIME_LIBRARY None)
+    target_link_libraries(deepmd_gnn PRIVATE deepmd_gnn_cudart ${CMAKE_DL_LIBS})
+  endif()
 endif()
 target_link_libraries(deepmd_gnn PRIVATE ${DEEPMD_GNN_TORCH_LIBRARIES})
 if(APPLE)

--- a/op/cudart/CMakeLists.txt
+++ b/op/cudart/CMakeLists.txt
@@ -1,0 +1,27 @@
+enable_language(C ASM)
+
+find_package(
+  Python3
+  COMPONENTS Interpreter
+  REQUIRED)
+
+get_property(
+  CUDART_LOCATION
+  TARGET CUDA::cudart
+  PROPERTY IMPORTED_LOCATION)
+execute_process(
+  COMMAND
+    ${Python3_EXECUTABLE} ${PROJECT_SOURCE_DIR}/third_party/implib/implib-gen.py
+    ${CUDART_LOCATION} --target ${CMAKE_SYSTEM_PROCESSOR} --dlopen-callback
+    DPGNN_cudart_dlopen --dlsym-callback DPGNN_cudart_dlsym
+    COMMAND_ERROR_IS_FATAL ANY
+  WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR})
+
+file(GLOB DEEPMD_GNN_CUDART_STUB_SRC ${CMAKE_CURRENT_BINARY_DIR}/*.tramp.S
+     ${CMAKE_CURRENT_BINARY_DIR}/*.init.c)
+
+add_library(deepmd_gnn_cudart OBJECT cudart_stub.cc
+                                     ${DEEPMD_GNN_CUDART_STUB_SRC})
+target_include_directories(deepmd_gnn_cudart PUBLIC ${CUDAToolkit_INCLUDE_DIRS})
+target_compile_definitions(deepmd_gnn_cudart PRIVATE IMPLIB_EXPORT_SHIMS)
+set_target_properties(deepmd_gnn_cudart PROPERTIES POSITION_INDEPENDENT_CODE ON)

--- a/op/cudart/cudart_stub.cc
+++ b/op/cudart/cudart_stub.cc
@@ -1,0 +1,76 @@
+// SPDX-License-Identifier: LGPL-3.0-or-later
+// Dynamically load the CUDA runtime library.
+
+#include <dlfcn.h>
+
+#include <string>
+
+#include "cuda_runtime_api.h"
+
+namespace {
+
+bool cudart_missing = false;
+
+cudaError_t DPGNN_CudartGetSymbolNotFoundError(...) {
+  return cudaErrorSharedObjectSymbolNotFound;
+}
+
+const char* DPGNN_CudartGetSymbolNotFoundString(cudaError_t) {
+  return "CUDA runtime library or symbol not found";
+}
+
+const char* DPGNN_CudartGetSymbolNotFoundName(cudaError_t) {
+  return "cudaErrorSharedObjectSymbolNotFound";
+}
+
+void** DPGNN_CudartRegisterFatBinary(...) { return nullptr; }
+
+void DPGNN_CudartNoOp(...) {}
+
+void* DPGNN_CudartFallback(const char* sym_name) {
+  const std::string symbol(sym_name);
+  if (symbol == "cudaGetErrorString") {
+    return reinterpret_cast<void*>(&DPGNN_CudartGetSymbolNotFoundString);
+  }
+  if (symbol == "cudaGetErrorName") {
+    return reinterpret_cast<void*>(&DPGNN_CudartGetSymbolNotFoundName);
+  }
+  if (symbol == "__cudaRegisterFatBinary") {
+    return reinterpret_cast<void*>(&DPGNN_CudartRegisterFatBinary);
+  }
+  if (symbol == "__cudaRegisterFatBinaryEnd" ||
+      symbol == "__cudaUnregisterFatBinary" ||
+      symbol == "__cudaRegisterFunction" || symbol == "__cudaRegisterVar") {
+    return reinterpret_cast<void*>(&DPGNN_CudartNoOp);
+  }
+  return reinterpret_cast<void*>(&DPGNN_CudartGetSymbolNotFoundError);
+}
+
+}  // namespace
+
+extern "C" {
+
+void* DPGNN_cudart_dlopen(const char* libname) {
+  static void* handle = [](const std::string& name) -> void* {
+    void* dso_handle = dlopen(name.c_str(), RTLD_NOW | RTLD_LOCAL);
+    if (!dso_handle) {
+      cudart_missing = true;
+      return dlopen(nullptr, RTLD_NOW | RTLD_LOCAL);
+    }
+    return dso_handle;
+  }(std::string(libname));
+  return handle;
+}
+
+void* DPGNN_cudart_dlsym(void* handle, const char* sym_name) {
+  if (!handle || cudart_missing) {
+    return DPGNN_CudartFallback(sym_name);
+  }
+  void* symbol = dlsym(handle, sym_name);
+  if (!symbol) {
+    return DPGNN_CudartFallback(sym_name);
+  }
+  return symbol;
+}
+
+}  // extern "C"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -86,6 +86,11 @@ BUILD_CPP_IF = false
 [tool.setuptools_scm]
 version_file = "deepmd_gnn/_version.py"
 
+[tool.ruff]
+extend-exclude = [
+    "third_party/implib",
+]
+
 [tool.ruff.lint]
 select = [
     "ALL",

--- a/third_party/README.md
+++ b/third_party/README.md
@@ -1,0 +1,5 @@
+# Third-party components
+
+| Component | Source                            | Version                                  | License |
+| --------- | --------------------------------- | ---------------------------------------- | ------- |
+| Implib.so | https://github.com/yugr/Implib.so | 30e547b2e8d608f7cd69bc8ec88d047034a40e35 | MIT     |

--- a/third_party/implib/LICENSE.txt
+++ b/third_party/implib/LICENSE.txt
@@ -1,0 +1,21 @@
+The MIT License (MIT)
+
+Copyright (c) 2017-2025 Yury Gribov
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/third_party/implib/arch/README.md
+++ b/third_party/implib/arch/README.md
@@ -1,0 +1,9 @@
+This folder contains target-specific config files and code snippets.
+
+Basically to add a new target one needs to provide an .ini file with basic platform info
+(like pointer sizes) and code templates for
+  * shim code which checks that real function address is available (and either jumps there or calls the slow path)
+  * the "slow path" code which
+    - saves function arguments (to avoid trashing them in next steps)
+    - calls code which loads the target library and locates function addresses
+    - restores saved arguments and returns

--- a/third_party/implib/arch/aarch64/config.ini
+++ b/third_party/implib/arch/aarch64/config.ini
@@ -1,0 +1,3 @@
+[Arch]
+PointerSize = 8
+SymbolReloc = R_AARCH64_ABS64

--- a/third_party/implib/arch/aarch64/table.S.tpl
+++ b/third_party/implib/arch/aarch64/table.S.tpl
@@ -1,0 +1,81 @@
+/*
+ * Copyright 2018-2025 Yury Gribov
+ *
+ * The MIT License (MIT)
+ *
+ * Use of this source code is governed by MIT license that can be
+ * found in the LICENSE.txt file.
+ */
+
+#define lr x30
+#define ip0 x16
+
+  .section .note.GNU-stack,"",@progbits
+
+  .data
+
+  .globl _${lib_suffix}_tramp_table
+  .hidden _${lib_suffix}_tramp_table
+  .align 8
+_${lib_suffix}_tramp_table:
+  .zero $table_size
+
+  .text
+
+  .globl _${lib_suffix}_tramp_resolve
+  .hidden _${lib_suffix}_tramp_resolve
+
+  .globl _${lib_suffix}_save_regs_and_resolve
+  .hidden _${lib_suffix}_save_regs_and_resolve
+  .type _${lib_suffix}_save_regs_and_resolve, %function
+_${lib_suffix}_save_regs_and_resolve:
+  .cfi_startproc
+
+  // Slow path which calls dlsym, taken only on first call.
+  // Registers are saved according to "Procedure Call Standard for the Arm® 64-bit Architecture".
+  // For DWARF directives, read https://www.imperialviolet.org/2017/01/18/cfi.html.
+
+  // Stack is aligned at 16 bytes
+
+#define PUSH_PAIR(reg1, reg2) stp reg1, reg2, [sp, #-16]!; .cfi_adjust_cfa_offset 16; .cfi_rel_offset reg1, 0; .cfi_rel_offset reg2, 8
+#define POP_PAIR(reg1, reg2) ldp reg1, reg2, [sp], #16; .cfi_adjust_cfa_offset -16; .cfi_restore reg2; .cfi_restore reg1
+
+#define PUSH_WIDE_PAIR(reg1, reg2) stp reg1, reg2, [sp, #-32]!; .cfi_adjust_cfa_offset 32; .cfi_rel_offset reg1, 0; .cfi_rel_offset reg2, 16
+#define POP_WIDE_PAIR(reg1, reg2) ldp reg1, reg2, [sp], #32; .cfi_adjust_cfa_offset -32; .cfi_restore reg2; .cfi_restore reg1
+
+  // Save only arguments (and lr)
+  PUSH_PAIR(x0, x1)
+  PUSH_PAIR(x2, x3)
+  PUSH_PAIR(x4, x5)
+  PUSH_PAIR(x6, x7)
+  PUSH_PAIR(x8, lr)
+
+  ldr x0, [sp, #80]  // 16*5
+
+  PUSH_WIDE_PAIR(q0, q1)
+  PUSH_WIDE_PAIR(q2, q3)
+  PUSH_WIDE_PAIR(q4, q5)
+  PUSH_WIDE_PAIR(q6, q7)
+
+  // Stack is aligned at 16 bytes
+
+  bl _${lib_suffix}_tramp_resolve
+  mov ip0, x0
+
+  // TODO: pop pc?
+
+  POP_WIDE_PAIR(q6, q7)
+  POP_WIDE_PAIR(q4, q5)
+  POP_WIDE_PAIR(q2, q3)
+  POP_WIDE_PAIR(q0, q1)
+
+  POP_PAIR(x8, lr)
+  POP_PAIR(x6, x7)
+  POP_PAIR(x4, x5)
+  POP_PAIR(x2, x3)
+  POP_PAIR(x0, x1)
+
+  br lr
+
+  .cfi_endproc
+

--- a/third_party/implib/arch/aarch64/trampoline.S.tpl
+++ b/third_party/implib/arch/aarch64/trampoline.S.tpl
@@ -1,0 +1,41 @@
+/*
+ * Copyright 2018-2025 Yury Gribov
+ *
+ * The MIT License (MIT)
+ *
+ * Use of this source code is governed by MIT license that can be
+ * found in the LICENSE.txt file.
+ */
+
+  .globl $sym
+  .p2align 4
+  .type $sym, %function
+#ifndef IMPLIB_EXPORT_SHIMS
+  .hidden $sym
+#endif
+$sym:
+  .cfi_startproc
+
+1:
+  // Load address
+  // TODO: can we do this faster on newer ARMs?
+  adrp ip0, _${lib_suffix}_tramp_table+$offset
+  ldr ip0, [ip0, #:lo12:_${lib_suffix}_tramp_table+$offset]
+ 
+  cbz ip0, 2f
+
+  // Fast path
+  br ip0
+
+2:
+  // Slow path
+  mov ip0, $number & 0xffff
+#if $number > 0xffff
+  movk ip0, $number >> 16, lsl #16
+#endif
+  stp ip0, lr, [sp, #-16]!; .cfi_adjust_cfa_offset 16; .cfi_rel_offset lr, 8
+  bl _${lib_suffix}_save_regs_and_resolve
+  ldp xzr, lr, [sp], #16; .cfi_adjust_cfa_offset -16; .cfi_restore lr
+  br ip0
+  .cfi_endproc
+

--- a/third_party/implib/arch/arm/config.ini
+++ b/third_party/implib/arch/arm/config.ini
@@ -1,0 +1,3 @@
+[Arch]
+PointerSize = 4
+SymbolReloc = R_ARM_ABS32

--- a/third_party/implib/arch/arm/table.S.tpl
+++ b/third_party/implib/arch/arm/table.S.tpl
@@ -1,0 +1,92 @@
+/*
+ * Copyright 2018-2025 Yury Gribov
+ *
+ * The MIT License (MIT)
+ *
+ * Use of this source code is governed by MIT license that can be
+ * found in the LICENSE.txt file.
+ */
+
+  .section .note.GNU-stack,"",%progbits
+
+  .data
+
+  .globl _${lib_suffix}_tramp_table
+  .hidden _${lib_suffix}_tramp_table
+  .align 4
+_${lib_suffix}_tramp_table:
+  .zero $table_size
+
+  .text
+
+  .globl _${lib_suffix}_tramp_resolve
+  .hidden _${lib_suffix}_tramp_resolve
+
+  .globl _${lib_suffix}_save_regs_and_resolve
+  .hidden _${lib_suffix}_save_regs_and_resolve
+  .type _${lib_suffix}_save_regs_and_resolve, %function
+_${lib_suffix}_save_regs_and_resolve:
+  .cfi_startproc
+
+#define PUSH_REG(reg) push {reg}; .cfi_adjust_cfa_offset 4; .cfi_rel_offset reg, 0
+#define POP_REG(reg) pop {reg} ; .cfi_adjust_cfa_offset -4; .cfi_restore reg
+
+// Binutils 2.30 does not like q0 in .cfi_rel_offset
+#define PUSH_DREG_PAIR(reg1, reg2) vpush {reg1, reg2}; .cfi_adjust_cfa_offset 16; .cfi_rel_offset reg1, 0; .cfi_rel_offset reg2, 8
+#define POP_DREG_PAIR(reg1, reg2) vpop {reg1, reg2}; .cfi_adjust_cfa_offset -16; .cfi_restore reg1; .cfi_restore reg2
+
+  // Slow path which calls dlsym, taken only on first call.
+  // Registers are saved acc. to "Procedure Call Standard for the ARM Architecture".
+  // For DWARF directives, read https://www.imperialviolet.org/2017/01/18/cfi.html.
+
+  // Stack is aligned at 16 bytes at this point
+
+  // Save only arguments (and lr)
+  PUSH_REG(r0)
+  ldr r0, [sp, #8]
+  PUSH_REG(r1)
+  PUSH_REG(r2)
+  PUSH_REG(r3)
+  PUSH_REG(lr)
+  PUSH_REG(lr)  // Align to 8 bytes
+
+  // Arguments can be passed in VFP registers only when hard-float ABI is used
+  // for arm-gnueabihf target // (http://android-doc.github.io/ndk/guides/abis.html#v7a).
+  // Use compiler macro to detect this case.
+#ifdef __ARM_PCS_VFP
+  PUSH_DREG_PAIR(d0, d1)
+  PUSH_DREG_PAIR(d2, d3)
+  PUSH_DREG_PAIR(d4, d5)
+  PUSH_DREG_PAIR(d6, d7)
+  PUSH_DREG_PAIR(d8, d9)
+  PUSH_DREG_PAIR(d10, d11)
+  PUSH_DREG_PAIR(d12, d13)
+  PUSH_DREG_PAIR(d14, d15)
+  // FIXME: NEON actually supports 32 D-registers but it's unclear how to detect this
+#endif
+
+  bl _${lib_suffix}_tramp_resolve(PLT)
+  mov ip, r0
+
+#ifdef __ARM_PCS_VFP
+  POP_DREG_PAIR(d14, d15)
+  POP_DREG_PAIR(d12, d13)
+  POP_DREG_PAIR(d10, d11)
+  POP_DREG_PAIR(d8, d9)
+  POP_DREG_PAIR(d6, d7)
+  POP_DREG_PAIR(d4, d5)
+  POP_DREG_PAIR(d2, d3)
+  POP_DREG_PAIR(d0, d1)
+#endif
+
+  POP_REG(lr)  // TODO: pop pc?
+  POP_REG(lr)
+  POP_REG(r3)
+  POP_REG(r2)
+  POP_REG(r1)
+  POP_REG(r0)
+
+  bx lr
+
+  .cfi_endproc
+

--- a/third_party/implib/arch/arm/trampoline.S.tpl
+++ b/third_party/implib/arch/arm/trampoline.S.tpl
@@ -1,0 +1,50 @@
+/*
+ * Copyright 2018-2025 Yury Gribov
+ *
+ * The MIT License (MIT)
+ *
+ * Use of this source code is governed by MIT license that can be
+ * found in the LICENSE.txt file.
+ */
+
+  .globl $sym
+  .p2align 4
+  .type $sym, %function
+#ifndef IMPLIB_EXPORT_SHIMS
+  .hidden $sym
+#endif
+$sym:
+  .cfi_startproc
+
+1:
+  // Load address
+  // TODO: can we do this faster on newer ARMs?
+  ldr ip, 3f
+2:
+  add ip, pc, ip
+  ldr ip, [ip]
+
+  cmp ip, #0
+
+  // Fast path
+  bxne ip
+
+  // Slow path
+  ldr ip, =$number
+  push {ip}
+  .cfi_adjust_cfa_offset 4
+  PUSH_REG(lr)
+  bl _${lib_suffix}_save_regs_and_resolve
+  POP_REG(lr)
+  add sp, #4
+  .cfi_adjust_cfa_offset -4
+  bx ip
+
+  // Force constant pool for ldr above
+  .ltorg
+
+  .cfi_endproc
+
+3:
+  .word _${lib_suffix}_tramp_table - (2b + 8) + $offset
+

--- a/third_party/implib/arch/common/init.c.tpl
+++ b/third_party/implib/arch/common/init.c.tpl
@@ -1,0 +1,245 @@
+/*
+ * Copyright 2018-2025 Yury Gribov
+ *
+ * The MIT License (MIT)
+ *
+ * Use of this source code is governed by MIT license that can be
+ * found in the LICENSE.txt file.
+ */
+
+#ifndef _GNU_SOURCE
+#define _GNU_SOURCE // For RTLD_DEFAULT
+#endif
+
+#define HAS_DLOPEN_CALLBACK $has_dlopen_callback
+#define HAS_DLSYM_CALLBACK $has_dlsym_callback
+#define NO_DLOPEN $no_dlopen
+#define LAZY_LOAD $lazy_load
+#define THREAD_SAFE $thread_safe
+
+#include <dlfcn.h>
+#include <stdlib.h>
+#include <string.h>
+#include <stdio.h>
+#include <assert.h>
+
+#if THREAD_SAFE
+#include <pthread.h>
+#endif
+
+// Sanity check for ARM to avoid puzzling runtime crashes
+#ifdef __arm__
+# if defined __thumb__ && ! defined __THUMB_INTERWORK__
+#   error "ARM trampolines need -mthumb-interwork to work in Thumb mode"
+# endif
+#endif
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+#define CHECK(cond, fmt, ...) do { \
+    if(!(cond)) { \
+      fprintf(stderr, "implib-gen: $load_name: " fmt "\n", ##__VA_ARGS__); \
+      assert(0 && "Assertion in generated code"); \
+      abort(); \
+    } \
+  } while(0)
+
+static void *lib_handle;
+static int dlopened;
+
+#if ! NO_DLOPEN
+
+#if THREAD_SAFE
+
+// We need to consider two cases:
+// - different threads calling intercepted APIs in parallel
+// - same thread calling 2 intercepted APIs recursively
+//   due to dlopen calling library constructors
+//   (usually happens only under IMPLIB_EXPORT_SHIMS)
+
+// Current recursive mutex approach will deadlock
+// if library constructor starts and joins a new thread
+// which (directly or indirectly) calls another library function.
+// Such situations should be very rare (although chances
+// are higher when -DIMLIB_EXPORT_SHIMS are enabled).
+//
+// Similar issue is present in Glibc so hopefully it's
+// not a big deal: // http://sourceware.org/bugzilla/show_bug.cgi?id=15686
+// (also google for "dlopen deadlock).
+
+static pthread_mutex_t mtx;
+static int rec_count;
+
+static void init_lock(void) {
+  // We need recursive lock because dlopen will call library constructors
+  // which may call other intercepted APIs that will call load_library again.
+  // PTHREAD_RECURSIVE_MUTEX_INITIALIZER is not portable
+  // so we do it hard way.
+
+  pthread_mutexattr_t attr;
+  CHECK(0 == pthread_mutexattr_init(&attr), "failed to init mutex");
+  CHECK(0 == pthread_mutexattr_settype(&attr, PTHREAD_MUTEX_RECURSIVE), "failed to init mutex");
+
+  CHECK(0 == pthread_mutex_init(&mtx, &attr), "failed to init mutex");
+}
+
+static int lock(void) {
+  static pthread_once_t once = PTHREAD_ONCE_INIT;
+  CHECK(0 == pthread_once(&once, init_lock), "failed to init lock");
+
+  CHECK(0 == pthread_mutex_lock(&mtx), "failed to lock mutex");
+
+  return 0 == __sync_fetch_and_add(&rec_count, 1);
+}
+
+static void unlock(void) {
+  __sync_fetch_and_add(&rec_count, -1);
+  CHECK(0 == pthread_mutex_unlock(&mtx), "failed to unlock mutex");
+}
+#else
+static int lock(void) {
+  return 1;
+}
+static void unlock(void) {}
+#endif
+
+static int load_library(void) {
+  int publish = lock();
+
+  if (lib_handle) {
+    unlock();
+    return publish;
+  }
+
+#if HAS_DLOPEN_CALLBACK
+  extern void *$dlopen_callback(const char *lib_name);
+  lib_handle = $dlopen_callback("$load_name");
+  CHECK(lib_handle, "failed to load library '$load_name' via callback '$dlopen_callback'");
+#else
+  lib_handle = dlopen("$load_name", RTLD_LAZY | RTLD_GLOBAL);
+  CHECK(lib_handle, "failed to load library '$load_name' via dlopen: %s", dlerror());
+#endif
+
+  // With (non-default) IMPLIB_EXPORT_SHIMS we may call dlopen more than once
+  // so dlclose it if we are not the first ones
+  if (__sync_val_compare_and_swap(&dlopened, 0, 1)) {
+    dlclose(lib_handle);
+  }
+
+  unlock();
+
+  return publish;
+}
+
+// Run dtor as late as possible in case library functions are
+// called in other global dtors
+// FIXME: this may crash if one thread is calling into library
+// while some other thread executes exit(). It's no clear
+// how to fix this besides simply NOT dlclosing library at all.
+static void __attribute__((destructor(101))) unload_lib(void) {
+  if (dlopened) {
+    dlclose(lib_handle);
+    lib_handle = 0;
+    dlopened = 0;
+  }
+}
+#endif
+
+#if ! NO_DLOPEN && ! LAZY_LOAD
+static void __attribute__((constructor(101))) load_lib(void) {
+  load_library();
+}
+#endif
+
+// TODO: convert to single 0-separated string
+static const char *const sym_names[] = {
+  $sym_names
+  0
+};
+
+#define SYM_COUNT (sizeof(sym_names)/sizeof(sym_names[0]) - 1)
+
+extern void *_${lib_suffix}_tramp_table[];
+
+// Can be sped up by manually parsing library symtab...
+void *_${lib_suffix}_tramp_resolve(size_t i) {
+  assert(i < SYM_COUNT);
+
+  int publish = 1;
+
+  void *h = 0;
+#if NO_DLOPEN
+  // Library with implementations must have already been loaded.
+  if (lib_handle) {
+    // User has specified loaded library
+    h = lib_handle;
+  } else {
+    // User hasn't provided us the loaded library so search the global namespace.
+#   ifndef IMPLIB_EXPORT_SHIMS
+    // If shim symbols are hidden we should search
+    // for first available definition of symbol in library list
+    h = RTLD_DEFAULT;
+#   else
+    // Otherwise look for next available definition
+    h = RTLD_NEXT;
+#   endif
+  }
+#else
+  publish = load_library();
+  h = lib_handle;
+  CHECK(h, "failed to resolve symbol '%s', library failed to load", sym_names[i]);
+#endif
+
+  void *addr;
+#if HAS_DLSYM_CALLBACK
+  extern void *$dlsym_callback(void *handle, const char *sym_name);
+  addr = $dlsym_callback(h, sym_names[i]);
+  CHECK(addr, "failed to resolve symbol '%s' via callback $dlsym_callback", sym_names[i]);
+#else
+  // Dlsym is thread-safe so don't need to protect it.
+  addr = dlsym(h, sym_names[i]);
+  CHECK(addr, "failed to resolve symbol '%s' via dlsym: %s", sym_names[i], dlerror());
+#endif
+
+  if (publish) {
+    // Use atomic to please Tsan and ensure that preceeding writes
+    // in library ctors have been delivered before publishing address
+    (void)__sync_val_compare_and_swap(&_${lib_suffix}_tramp_table[i], 0, addr);
+  }
+
+  return addr;
+}
+
+// Below APIs are not thread-safe
+// and it's not clear how make them such
+// (we can not know if some other thread is
+// currently executing library code).
+
+// Helper for user to resolve all symbols
+void _${lib_suffix}_tramp_resolve_all(void) {
+  size_t i;
+  for(i = 0; i < SYM_COUNT; ++i)
+    _${lib_suffix}_tramp_resolve(i);
+}
+
+// Allows user to specify manually loaded implementation library.
+void _${lib_suffix}_tramp_set_handle(void *handle) {
+  // TODO: call unload_lib ?
+  lib_handle = handle;
+  dlopened = 0;
+}
+
+// Resets all resolved symbols. This is needed in case
+// client code wants to reload interposed library multiple times.
+void _${lib_suffix}_tramp_reset(void) {
+  // TODO: call unload_lib ?
+  memset(_${lib_suffix}_tramp_table, 0, SYM_COUNT * sizeof(_${lib_suffix}_tramp_table[0]));
+  lib_handle = 0;
+  dlopened = 0;
+}
+
+#ifdef __cplusplus
+}  // extern "C"
+#endif

--- a/third_party/implib/arch/e2k/README.md
+++ b/third_party/implib/arch/e2k/README.md
@@ -1,0 +1,4 @@
+Reference materials:
+  * Руководство по эффективному программированию на платформе «Эльбрус» (http://www.mcst.ru/files/5ed39a/dd0cd8/50506b/000000/elbrus_prog_2020-05-30.pdf)
+  * Микропроцессоры и вычислительные комплексы семейства Эльбрус (http://www.mcst.ru/doc/book_121130.pdf)
+  * https://github.com/OpenE2K

--- a/third_party/implib/arch/e2k/config.ini
+++ b/third_party/implib/arch/e2k/config.ini
@@ -1,0 +1,3 @@
+[Arch]
+PointerSize = 8
+SymbolReloc = R_E2K_DISP, R_E2K_64_ABS_LIT, R_E2K_64_ABS

--- a/third_party/implib/arch/e2k/table.S.tpl
+++ b/third_party/implib/arch/e2k/table.S.tpl
@@ -1,0 +1,43 @@
+/*
+ * Copyright 2022 Yury Gribov
+ *
+ * The MIT License (MIT)
+ *
+ * Use of this source code is governed by MIT license that can be
+ * found in the LICENSE.txt file.
+ */
+
+  .data
+
+  .globl _${lib_suffix}_tramp_table
+  .hidden _${lib_suffix}_tramp_table
+  .ignore strict_delay
+  .p2align 3
+_${lib_suffix}_tramp_table:
+  .zero $table_size
+
+  .text
+
+  .globl _${lib_suffix}_tramp_resolve
+  .hidden _${lib_suffix}_tramp_resolve
+
+  .globl _${lib_suffix}_save_regs_and_resolve
+  .hidden _${lib_suffix}_save_regs_and_resolve
+  .type _${lib_suffix}_save_regs_and_resolve, %function
+_${lib_suffix}_save_regs_and_resolve:
+  .cfi_startproc
+
+  setwd wsz = 0x1, nfx = 1
+
+  addd 0x0, %g0, %r0
+
+  disp  %ctpr1, _${lib_suffix}_tramp_resolve
+  call %ctpr1, wbs = 0
+
+  movtd %r0, %ctpr1
+
+  return %ctpr3
+  ct %ctpr3
+
+  .cfi_endproc
+

--- a/third_party/implib/arch/e2k/trampoline.S.tpl
+++ b/third_party/implib/arch/e2k/trampoline.S.tpl
@@ -1,0 +1,56 @@
+/*
+ * Copyright 2022-2025 Yury Gribov
+ *
+ * The MIT License (MIT)
+ *
+ * Use of this source code is governed by MIT license that can be
+ * found in the LICENSE.txt file.
+ */
+
+  .globl $sym
+  .p2align 3
+  .ignore strict_delay
+  .type $sym, %function
+#ifndef IMPLIB_EXPORT_SHIMS
+  .hidden $sym
+#endif
+$sym:
+  .cfi_startproc
+
+  setwd wsz = 0x8, nfx = 0x1
+
+1:
+  // Read table address
+  {
+    rrd %ip, %g0
+    addd 0x0, [ _f64 _GLOBAL_OFFSET_TABLE_ ], %g1
+  }
+  addd %g0, %g1, %g0
+  addd %g0, [ _f64 _${lib_suffix}_tramp_table@GOTOFF ], %g0
+
+  // Read current function address
+  ldd [%g0 + $offset], %g0
+
+  // NULL?
+  {
+    cmpesb %g0, 0x0, %pred0
+    movtd %g0, %ctpr2
+  }
+
+  // Jump to fast path
+  ct %ctpr2 ? ~%pred0
+
+  // Or fall through to slow path
+
+2:
+  // Initialize parameter
+  addd 0x0, _f16s $number, %g0
+
+  // Call resolver
+  disp  %ctpr1, _${lib_suffix}_save_regs_and_resolve
+  call %ctpr1, wbs = 0x8
+
+  ct %ctpr1
+
+  .cfi_endproc
+

--- a/third_party/implib/arch/i386/config.ini
+++ b/third_party/implib/arch/i386/config.ini
@@ -1,0 +1,3 @@
+[Arch]
+PointerSize = 4
+SymbolReloc = R_386_32

--- a/third_party/implib/arch/i386/table.S.tpl
+++ b/third_party/implib/arch/i386/table.S.tpl
@@ -1,0 +1,85 @@
+/*
+ * Copyright 2019-2025 Yury Gribov
+ *
+ * The MIT License (MIT)
+ *
+ * Use of this source code is governed by MIT license that can be
+ * found in the LICENSE.txt file.
+ */
+
+  .section .note.GNU-stack,"",@progbits
+
+  .data
+
+  .globl _${lib_suffix}_tramp_table
+  .hidden _${lib_suffix}_tramp_table
+  .align 4
+_${lib_suffix}_tramp_table:
+  .zero $table_size
+
+  .text
+
+  .globl _${lib_suffix}_tramp_resolve
+  .hidden _${lib_suffix}_tramp_resolve
+
+  .globl _${lib_suffix}_save_regs_and_resolve
+  .hidden _${lib_suffix}_save_regs_and_resolve
+  .type _${lib_suffix}_save_regs_and_resolve, %function
+_${lib_suffix}_save_regs_and_resolve:
+  .cfi_startproc
+
+#define PUSH_REG(reg) pushl %reg ; .cfi_adjust_cfa_offset 4; .cfi_rel_offset reg, 0
+#define POP_REG(reg) popl %reg ; .cfi_adjust_cfa_offset -4; .cfi_restore reg
+
+  // Slow path which calls dlsym, taken only on first call.
+  // All registers except EAX are stored to handle arbitrary calling conventions
+  // (except XMM/x87 regs in hope they are not used in resolving code).
+  // For Dwarf directives, read https://www.imperialviolet.org/2017/01/18/cfi.html.
+
+  .cfi_def_cfa_offset 4  // Return address
+
+  PUSH_REG(ebx)
+  PUSH_REG(ebx)
+  PUSH_REG(ecx)
+  PUSH_REG(edx)  // 16
+
+  PUSH_REG(ebp)
+  PUSH_REG(edi)
+  PUSH_REG(esi)
+  pushfl; .cfi_adjust_cfa_offset 4  // 16
+
+  subl $$8, %esp
+  .cfi_adjust_cfa_offset 8
+  PUSH_REG(eax)
+
+  // TODO: save vector regs
+
+  call _${lib_suffix}_tramp_resolve@PLT  // Stack will be aligned at 16 in call
+
+  addl $$12, %esp
+  .cfi_adjust_cfa_offset -12
+
+  popfl; .cfi_adjust_cfa_offset -4
+  POP_REG(esi)
+  POP_REG(edi)
+  POP_REG(ebp)
+
+  POP_REG(edx)
+  POP_REG(ecx)
+  POP_REG(ebx)
+  POP_REG(ebx)
+
+  ret
+
+  .cfi_endproc
+
+  .section .text.__implib.x86.get_pc_thunk.ax,"axG",@progbits,__implib.x86.get_pc_thunk.ax,comdat
+  .globl __implib.x86.get_pc_thunk.ax
+  .hidden __implib.x86.get_pc_thunk.ax
+  .type __implib.x86.get_pc_thunk.ax, %function
+__implib.x86.get_pc_thunk.ax:
+  .cfi_startproc
+  movl (%esp), %eax
+  ret
+  .cfi_endproc
+

--- a/third_party/implib/arch/i386/trampoline.S.tpl
+++ b/third_party/implib/arch/i386/trampoline.S.tpl
@@ -1,0 +1,33 @@
+/*
+ * Copyright 2019-2025 Yury Gribov
+ *
+ * The MIT License (MIT)
+ *
+ * Use of this source code is governed by MIT license that can be
+ * found in the LICENSE.txt file.
+ */
+
+  .globl $sym
+  .p2align 4
+  .type $sym, %function
+#ifndef IMPLIB_EXPORT_SHIMS
+  .hidden $sym
+#endif
+$sym:
+  .cfi_startproc
+  .cfi_def_cfa_offset 4  // Return address
+  // add $$0, %rsp  Why GDB fails to step over call without this?!
+  // x86 has no support for PC-relative addressing so code is not very efficient.
+  // We also trash EAX here (it's call-clobbered in cdecl).
+  call __implib.x86.get_pc_thunk.ax
+  addl $$_GLOBAL_OFFSET_TABLE_, %eax
+  movl $offset+_${lib_suffix}_tramp_table@GOTOFF(%eax), %eax
+  cmp $$0, %eax
+  je 2f
+1:
+  jmp *%eax
+2:
+  mov $$$number, %eax
+  call _${lib_suffix}_save_regs_and_resolve
+  jmp *%eax
+  .cfi_endproc

--- a/third_party/implib/arch/mips/config.ini
+++ b/third_party/implib/arch/mips/config.ini
@@ -1,0 +1,3 @@
+[Arch]
+PointerSize = 4
+SymbolReloc = R_MIPS_REL32

--- a/third_party/implib/arch/mips/table.S.tpl
+++ b/third_party/implib/arch/mips/table.S.tpl
@@ -1,0 +1,84 @@
+/*
+ * Copyright 2022-2024 Yury Gribov
+ *
+ * The MIT License (MIT)
+ *
+ * Use of this source code is governed by MIT license that can be
+ * found in the LICENSE.txt file.
+ */
+
+  .section .note.GNU-stack,"",@progbits
+
+  .data
+
+  .globl _${lib_suffix}_tramp_table
+  .hidden _${lib_suffix}_tramp_table
+  .align 4
+_${lib_suffix}_tramp_table:
+  .zero $table_size
+
+  .text
+
+  .globl _${lib_suffix}_tramp_resolve
+  .hidden _${lib_suffix}_tramp_resolve
+
+  .globl _${lib_suffix}_save_regs_and_resolve
+  .hidden _${lib_suffix}_save_regs_and_resolve
+  .type _${lib_suffix}_save_regs_and_resolve, %function
+_${lib_suffix}_save_regs_and_resolve:
+  .cfi_startproc
+
+  .set noreorder
+  .cpload $$25
+  .set nomacro
+  .set noat
+
+  // Slow path which calls dlsym, taken only on first call.
+  // Registers are saved acc. to "Procedure Call Standard for the MIPS Architecture".
+  // For DWARF directives, read https://www.imperialviolet.org/2017/01/18/cfi.html.
+
+  // TODO: push two regs at once here and in trampoline to avoid temporarily unaligned stack
+
+#define PUSH_REG(reg) addiu $$sp, $$sp, -4; .cfi_adjust_cfa_offset 4; sw reg, 4($$sp); .cfi_rel_offset reg, 0
+#define POP_REG(reg) addiu $$sp, $$sp, 4; .cfi_adjust_cfa_offset -4; lw reg, 0($$sp); .cfi_restore reg
+
+// dwarf_num = 32 + reg_num
+#define PUSH_FREG(reg, dwarf_num) addiu $$sp, $$sp, -8; .cfi_adjust_cfa_offset 8; sdc1 reg, 8($$sp); .cfi_rel_offset dwarf_num, 0; .cfi_rel_offset dwarf_num + 1, 4
+#define POP_FREG(reg, dwarf_num) addiu $$sp, $$sp, 8; .cfi_adjust_cfa_offset -8; ldc1 reg, 0($$sp); .cfi_restore dwarf_num; .cfi_restore dwarf_num + 1
+
+  PUSH_REG($$ra)
+  PUSH_REG($$a0)
+  PUSH_REG($$a1)
+  PUSH_REG($$a2)
+  PUSH_REG($$a3)
+  PUSH_REG($$a3)  // For alignment
+
+  PUSH_FREG($$f12, 44)
+  PUSH_FREG($$f14, 46)
+
+  // Vector arguments are passed on stack so we don't save vector regs
+
+  move $$a0, $$AT
+
+  lw $$25, %call16(_${lib_suffix}_tramp_resolve)($$gp)
+  .reloc  1f, R_MIPS_JALR, _${lib_suffix}_tramp_resolve
+1: jalr $$25
+  nop
+
+  POP_FREG($$f14, 46)
+  POP_FREG($$f12, 44)
+
+  POP_REG($$a3)
+  POP_REG($$a3)
+  POP_REG($$a2)
+  POP_REG($$a1)
+  POP_REG($$a0)
+  POP_REG($$ra)
+
+  jr $$ra
+  nop
+
+  .set macro
+  .set reorder
+
+  .cfi_endproc

--- a/third_party/implib/arch/mips/trampoline.S.tpl
+++ b/third_party/implib/arch/mips/trampoline.S.tpl
@@ -1,0 +1,75 @@
+/*
+ * Copyright 2022-2025 Yury Gribov
+ *
+ * The MIT License (MIT)
+ *
+ * Use of this source code is governed by MIT license that can be
+ * found in the LICENSE.txt file.
+ */
+
+  .globl $sym
+  .p2align 4
+  .type $sym, %function
+#ifndef IMPLIB_EXPORT_SHIMS
+  .hidden $sym
+#endif
+$sym:
+  .cfi_startproc
+
+  .set noreorder
+  .cpload $$25
+
+  .set nomacro
+  .set noat
+
+1:
+  // Load address
+#if $offset < 32768
+  lw $$AT, %got(_${lib_suffix}_tramp_table)($$gp)
+  lw $$AT, $offset($$AT)
+#else
+  PUSH_REG($$2)
+  lw $$AT, %got(_${lib_suffix}_tramp_table)($$gp)
+  .set macro
+  .set at=$$2
+  lw $$AT, $offset($$AT)
+  .set nomacro
+  .set noat
+  POP_REG($$2)
+#endif
+
+  beqz $$AT, 3f
+  nop
+
+2:
+  // Fast path
+  j $$AT
+  move $$25, $$AT
+
+3:
+  // Slow path
+
+  PUSH_REG($$25)
+  PUSH_REG($$ra)
+
+  // Reserve space for 4 operands according to ABI
+  addiu $$sp, $$sp, -16; .cfi_adjust_cfa_offset 16
+
+  li $$AT, $number
+  lw $$25, %call16(_${lib_suffix}_save_regs_and_resolve)($$gp)
+  .reloc  4f, R_MIPS_JALR, _${lib_suffix}_save_regs_and_resolve
+4: jalr $$25
+  nop
+
+  addiu $$sp, $$sp, 16; .cfi_adjust_cfa_offset -16
+
+  POP_REG($$ra)
+  POP_REG($$25)
+
+  j $$v0
+  move $$25, $$v0
+
+  .set macro
+  .set reorder
+
+  .cfi_endproc

--- a/third_party/implib/arch/mips64/config.ini
+++ b/third_party/implib/arch/mips64/config.ini
@@ -1,0 +1,3 @@
+[Arch]
+PointerSize = 8
+SymbolReloc = R_MIPS_REL32

--- a/third_party/implib/arch/mips64/table.S.tpl
+++ b/third_party/implib/arch/mips64/table.S.tpl
@@ -1,0 +1,108 @@
+/*
+ * Copyright 2022-2024 Yury Gribov
+ *
+ * The MIT License (MIT)
+ *
+ * Use of this source code is governed by MIT license that can be
+ * found in the LICENSE.txt file.
+ */
+
+  .section .note.GNU-stack,"",@progbits
+
+  .data
+
+  .globl _${lib_suffix}_tramp_table
+  .hidden _${lib_suffix}_tramp_table
+  .align 8
+_${lib_suffix}_tramp_table:
+  .zero $table_size
+
+  .text
+
+  .globl _${lib_suffix}_tramp_resolve
+  .hidden _${lib_suffix}_tramp_resolve
+
+  .globl _${lib_suffix}_save_regs_and_resolve
+  .hidden _${lib_suffix}_save_regs_and_resolve
+  .type _${lib_suffix}_save_regs_and_resolve, %function
+_${lib_suffix}_save_regs_and_resolve:
+  .cfi_startproc
+
+  .set noreorder
+  .cpload $$25
+  .set nomacro
+  .set noat
+
+  // Slow path which calls dlsym, taken only on first call.
+  // Registers are saved acc. to "Procedure Call Standard for the MIPS Architecture".
+  // For DWARF directives, read https://www.imperialviolet.org/2017/01/18/cfi.html.
+
+  // TODO: push two regs at once here and in trampoline to avoid temporarily unaligned stack
+
+#define PUSH_REG(reg) daddiu $$sp, $$sp, -8; .cfi_adjust_cfa_offset 8; sd reg, 0($$sp); .cfi_rel_offset reg, 0
+#define POP_REG(reg) ld reg, 0($$sp); .cfi_restore reg; daddiu $$sp, $$sp, 8; .cfi_adjust_cfa_offset -8
+
+// dwarf_num = 32 + reg_num
+#define PUSH_FREG(reg, dwarf_num) daddiu $$sp, $$sp, -8; .cfi_adjust_cfa_offset 8; sdc1 reg, 0($$sp); .cfi_rel_offset dwarf_num, 0
+#define POP_FREG(reg, dwarf_num) ldc1 reg, 0($$sp); .cfi_restore dwarf_num; daddiu $$sp, $$sp, 8; .cfi_adjust_cfa_offset -8
+
+  PUSH_REG($$ra)
+  PUSH_REG($$gp)
+  PUSH_REG($$a0)
+  PUSH_REG($$a1)
+  PUSH_REG($$a2)
+  PUSH_REG($$a3)
+  PUSH_REG($$a4)
+  PUSH_REG($$a5)
+  PUSH_REG($$a6)
+  PUSH_REG($$a7)
+
+  PUSH_FREG($$f12, 44)
+  PUSH_FREG($$f13, 45)
+  PUSH_FREG($$f14, 46)
+  PUSH_FREG($$f15, 47)
+  PUSH_FREG($$f16, 48)
+  PUSH_FREG($$f17, 49)
+  PUSH_FREG($$f18, 50)
+  PUSH_FREG($$f19, 51)
+
+  // Vector arguments are passed on stack so we don't save vector regs
+
+  lui $$gp, %hi(%neg(%gp_rel(_${lib_suffix}_save_regs_and_resolve)))
+  daddu $$gp, $$gp, $$25
+  daddiu $$gp, $$gp, %lo(%neg(%gp_rel(_${lib_suffix}_save_regs_and_resolve)))
+
+  move $$a0, $$AT
+
+  ld $$25, %call16(_${lib_suffix}_tramp_resolve)($$gp)
+  .reloc  1f, R_MIPS_JALR, _${lib_suffix}_tramp_resolve
+1: jalr $$25
+  nop
+
+  POP_FREG($$f19, 51)
+  POP_FREG($$f18, 50)
+  POP_FREG($$f17, 49)
+  POP_FREG($$f16, 48)
+  POP_FREG($$f15, 47)
+  POP_FREG($$f14, 46)
+  POP_FREG($$f13, 45)
+  POP_FREG($$f12, 44)
+
+  POP_REG($$a7)
+  POP_REG($$a6)
+  POP_REG($$a5)
+  POP_REG($$a4)
+  POP_REG($$a3)
+  POP_REG($$a2)
+  POP_REG($$a1)
+  POP_REG($$a0)
+  POP_REG($$gp)
+  POP_REG($$ra)
+
+  jr $$ra
+  nop
+
+  .set macro
+  .set reorder
+
+  .cfi_endproc

--- a/third_party/implib/arch/mips64/trampoline.S.tpl
+++ b/third_party/implib/arch/mips64/trampoline.S.tpl
@@ -1,0 +1,80 @@
+/*
+ * Copyright 2022-2025 Yury Gribov
+ *
+ * The MIT License (MIT)
+ *
+ * Use of this source code is governed by MIT license that can be
+ * found in the LICENSE.txt file.
+ */
+
+  .globl $sym
+  .p2align 4
+  .type $sym, %function
+#ifndef IMPLIB_EXPORT_SHIMS
+  .hidden $sym
+#endif
+$sym:
+  .cfi_startproc
+
+  .set noreorder
+  .cpload $$25
+  .set nomacro
+  .set noat
+
+1:
+  // Load address
+#if $offset < 32768
+  lui $$AT, %hi(%neg(%gp_rel($sym)))
+  daddu $$AT, $$AT, $$25
+  daddiu $$AT, $$AT, %lo(%neg(%gp_rel($sym)))
+  ld $$AT, %got_disp(_${lib_suffix}_tramp_table)($$AT)
+  ld $$AT, $offset($$AT)
+#else
+  PUSH_REG($$2)
+  lui $$AT, %hi(%neg(%gp_rel($sym)))
+  daddu $$AT, $$AT, $$25
+  daddiu $$AT, $$AT, %lo(%neg(%gp_rel($sym)))
+  ld $$AT, %got_disp(_${lib_suffix}_tramp_table)($$AT)
+  .set macro
+  .set at=$$2
+  ld $$AT, $offset($$AT)
+  .set nomacro
+  .set noat
+  POP_REG($$2)
+#endif
+
+  beqz $$AT, 3f
+  nop
+
+2:
+  // Fast path
+  j $$AT
+  move $$25, $$AT
+
+3:
+  // Slow path
+
+  PUSH_REG($$25)
+  PUSH_REG($$ra)
+  PUSH_REG($$gp)
+
+  lui $$gp, %hi(%neg(%gp_rel($sym)))
+  daddu $$gp, $$gp, $$25
+  daddiu $$gp, $$gp, %lo(%neg(%gp_rel($sym)))
+
+  ld $$25, %call16(_${lib_suffix}_save_regs_and_resolve)($$gp)
+  .reloc  4f, R_MIPS_JALR, _${lib_suffix}_save_regs_and_resolve
+4: jalr $$25
+  li $$AT, $number
+
+  POP_REG($$gp)
+  POP_REG($$ra)
+  POP_REG($$25)
+
+  j $$v0
+  move $$25, $$v0
+
+  .set macro
+  .set reorder
+
+  .cfi_endproc

--- a/third_party/implib/arch/powerpc64/config.ini
+++ b/third_party/implib/arch/powerpc64/config.ini
@@ -1,0 +1,3 @@
+[Arch]
+PointerSize = 8
+SymbolReloc = R_PPC64_ADDR64

--- a/third_party/implib/arch/powerpc64/table.S.tpl
+++ b/third_party/implib/arch/powerpc64/table.S.tpl
@@ -1,0 +1,168 @@
+/*
+ * Copyright 2024-2025 Yury Gribov
+ *
+ * The MIT License (MIT)
+ *
+ * Use of this source code is governed by MIT license that can be
+ * found in the LICENSE.txt file.
+ */
+
+  .machine power7
+
+  .section .note.GNU-stack,"",@progbits
+
+  .data
+
+  .globl _${lib_suffix}_tramp_table
+  .hidden _${lib_suffix}_tramp_table
+  .align 8
+_${lib_suffix}_tramp_table:
+  .zero $table_size
+
+  .section ".toc","aw"
+  .align 3
+.LC0:
+  .quad _${lib_suffix}_tramp_table
+
+  .section ".text"
+
+  .globl _${lib_suffix}_tramp_resolve
+  .hidden _${lib_suffix}_tramp_resolve
+
+  .globl _${lib_suffix}_save_regs_and_resolve
+  .hidden _${lib_suffix}_save_regs_and_resolve
+  .type _${lib_suffix}_save_regs_and_resolve, %function
+
+  .section ".opd", "aw"
+  .align 3
+_${lib_suffix}_save_regs_and_resolve:
+  .quad .L._${lib_suffix}_save_regs_and_resolve, .TOC.@tocbase, 0
+
+  .previous
+
+.L._${lib_suffix}_save_regs_and_resolve:
+  .cfi_startproc
+
+  // Slow path which calls dlsym, taken only on first call.
+  // Registers are saved acc. to PPC64 ELF ABI
+  // For DWARF directives, read https://www.imperialviolet.org/2017/01/18/cfi.html.
+
+  mflr 0
+  std 0, 16(1)
+
+  ld 0, 128-8(1)
+
+  std 3, -8(1)
+  std 4, -16(1)
+  std 5, -24(1)
+  std 6, -32(1)
+  std 7, -40(1)
+  std 8, -48(1)
+  std 9, -56(1)
+  std 10, -64(1)
+
+  stfd 1, -72(1)
+  stfd 2, -80(1)
+  stfd 3, -88(1)
+  stfd 4, -96(1)
+  stfd 5, -104(1)
+  stfd 6, -112(1)
+  stfd 7, -120(1)
+  stfd 8, -128(1)
+  stfd 9, -136(1)
+  stfd 10, -144(1)
+  stfd 11, -152(1)
+  stfd 12, -160(1)
+  stfd 13, -168(1)
+
+  // TODO: also save Altivec registers
+
+  stdu 1, -256(1)
+
+  .cfi_def_cfa_offset 256
+  .cfi_offset r3, -8
+  .cfi_offset r4, -16
+  .cfi_offset r5, -24
+  .cfi_offset r6, -32
+  .cfi_offset r7, -40
+  .cfi_offset r8, -48
+  .cfi_offset r9, -56
+  .cfi_offset r10, -64
+  .cfi_offset f1, -72
+  .cfi_offset f2, -80
+  .cfi_offset f3, -88
+  .cfi_offset f4, -96
+  .cfi_offset f5, -104
+  .cfi_offset f6, -112
+  .cfi_offset f7, -120
+  .cfi_offset f8, -128
+  .cfi_offset f9, -136
+  .cfi_offset f10, -144
+  .cfi_offset f11, -152
+  .cfi_offset f12, -160
+  .cfi_offset f13, -168
+
+  mr 3, 0
+
+  bl _${lib_suffix}_tramp_resolve
+  nop
+
+  mr 11, 3
+
+  addi 1, 1, 256
+  .cfi_def_cfa_offset 0
+
+  ld 3, -8(1)
+  ld 4, -16(1)
+  ld 5, -24(1)
+  ld 6, -32(1)
+  ld 7, -40(1)
+  ld 8, -48(1)
+  ld 9, -56(1)
+  ld 10, -64(1)
+
+  lfd 1, -72(1)
+  lfd 2, -80(1)
+  lfd 3, -88(1)
+  lfd 4, -96(1)
+  lfd 5, -104(1)
+  lfd 6, -112(1)
+  lfd 7, -120(1)
+  lfd 8, -128(1)
+  lfd 9, -136(1)
+  lfd 10, -144(1)
+  lfd 11, -152(1)
+  lfd 12, -160(1)
+  lfd 13, -168(1)
+
+  ld 0, 16(1)
+  mtlr 0
+
+  .cfi_restore r3
+  .cfi_restore r4
+  .cfi_restore r5
+  .cfi_restore r6
+  .cfi_restore r7
+  .cfi_restore r8
+  .cfi_restore r9
+  .cfi_restore r10
+  .cfi_restore f1
+  .cfi_restore f2
+  .cfi_restore f3
+  .cfi_restore f4
+  .cfi_restore f5
+  .cfi_restore f6
+  .cfi_restore f7
+  .cfi_restore f8
+  .cfi_restore f9
+  .cfi_restore f10
+  .cfi_restore f11
+  .cfi_restore f12
+  .cfi_restore f13
+
+  blr
+
+  .long 0
+  .quad 0
+
+  .cfi_endproc

--- a/third_party/implib/arch/powerpc64/trampoline.S.tpl
+++ b/third_party/implib/arch/powerpc64/trampoline.S.tpl
@@ -1,0 +1,111 @@
+/*
+ * Copyright 2024-2025 Yury Gribov
+ *
+ * The MIT License (MIT)
+ *
+ * Use of this source code is governed by MIT license that can be
+ * found in the LICENSE.txt file.
+ */
+
+  .globl $sym
+  .p2align 4
+  .type $sym, %function
+#ifndef IMPLIB_EXPORT_SHIMS
+  .hidden $sym
+#endif
+
+  .section ".opd", "aw"
+  .align 3
+$sym:
+  .quad .L.$sym, .TOC.@tocbase, 0
+
+  .previous
+
+.L.$sym:
+  .cfi_startproc
+
+1:
+  // Load address
+  addis 11, 2, .LC0@toc@ha
+  ld 11, .LC0@toc@l(11)
+  ld 11, $offset(11)
+
+  cmpdi 11, 0
+  beq 3f
+
+2: // "Fast" path
+
+  // TODO:
+  // We need to somehow get rid of additional stack frame
+  // because it breaks arguments which are passed on stack.
+  // Currently we work around this by duplicating parameters
+  // in new stack frame but this supports only 16 parameters
+  // and is very inefficient.
+
+  mflr 0
+  std 0, 16(1)
+  stdu 1, -176(1)
+  .cfi_def_cfa_offset 176
+  .cfi_offset lr, 16
+
+  std 2, 40(1)
+
+  ld 0, 176+112(1)
+  std 0, 112(1)
+  ld 0, 176+120(1)
+  std 0, 120(1)
+  ld 0, 176+128(1)
+  std 0, 128(1)
+  ld 0, 176+136(1)
+  std 0, 136(1)
+  ld 0, 176+144(1)
+  std 0, 144(1)
+  ld 0, 176+152(1)
+  std 0, 152(1)
+  ld 0, 176+160(1)
+  std 0, 160(1)
+  ld 0, 176+168(1)
+  std 0, 168(1)
+
+  ld 2, 8(11)
+  ld 11, 0(11)
+
+  mtctr 11
+  bctrl
+
+  ld 2, 40(1)
+  addi 1, 1, 176
+  .cfi_def_cfa_offset 0
+  ld 0, 16(1)
+  mtlr 0
+  .cfi_restore lr
+  blr
+
+3: // Slow path
+
+  mflr 0
+  std 0, 16(1)
+
+  li 0, $number
+  std 0, -8(1)
+
+  stdu 1, -128(1)
+  .cfi_def_cfa_offset 128
+  .cfi_offset lr, 16
+
+  bl _${lib_suffix}_save_regs_and_resolve
+  nop
+
+  addi 1, 1, 128
+  .cfi_def_cfa_offset 0
+
+  ld 0, 16(1)
+  mtlr 0
+  .cfi_restore lr
+
+  b 2b
+
+  .long 0
+  .quad 0
+
+  .cfi_endproc

--- a/third_party/implib/arch/powerpc64le/config.ini
+++ b/third_party/implib/arch/powerpc64le/config.ini
@@ -1,0 +1,3 @@
+[Arch]
+PointerSize = 8
+SymbolReloc = R_PPC64_ADDR64

--- a/third_party/implib/arch/powerpc64le/table.S.tpl
+++ b/third_party/implib/arch/powerpc64le/table.S.tpl
@@ -1,0 +1,166 @@
+/*
+ * Copyright 2024-2025 Yury Gribov
+ *
+ * The MIT License (MIT)
+ *
+ * Use of this source code is governed by MIT license that can be
+ * found in the LICENSE.txt file.
+ */
+
+  .machine power9
+  .abiversion 2
+
+  .section .note.GNU-stack,"",@progbits
+
+  .data
+
+  .globl _${lib_suffix}_tramp_table
+  .hidden _${lib_suffix}_tramp_table
+  .align 8
+_${lib_suffix}_tramp_table:
+  .zero $table_size
+
+  .section ".toc","aw"
+  .align 3
+.LC0:
+  .quad _${lib_suffix}_tramp_table
+
+  .section ".text"
+
+  .globl _${lib_suffix}_tramp_resolve
+  .hidden _${lib_suffix}_tramp_resolve
+
+  .globl _${lib_suffix}_save_regs_and_resolve
+  .hidden _${lib_suffix}_save_regs_and_resolve
+  .type _${lib_suffix}_save_regs_and_resolve, %function
+
+_${lib_suffix}_save_regs_and_resolve:
+  .cfi_startproc
+.LCF0:
+  addis 2, 12, .TOC. - .LCF0@ha
+  addi 2, 2, .TOC. - .LCF0@l
+  .localentry _${lib_suffix}_save_regs_and_resolve, . - _${lib_suffix}_save_regs_and_resolve
+
+  // Slow path which calls dlsym, taken only on first call.
+  // Registers are saved acc. to PPC64 ELF ABI
+  // For DWARF directives, read https://www.imperialviolet.org/2017/01/18/cfi.html.
+
+  mflr 0
+  std 0, 16(1)
+
+  ld 0, 48-8(1)
+
+  std 3, -8(1)
+  std 4, -16(1)
+  std 5, -24(1)
+  std 6, -32(1)
+  std 7, -40(1)
+  std 8, -48(1)
+  std 9, -56(1)
+  std 10, -64(1)
+
+  stfd 1, -72(1)
+  stfd 2, -80(1)
+  stfd 3, -88(1)
+  stfd 4, -96(1)
+  stfd 5, -104(1)
+  stfd 6, -112(1)
+  stfd 7, -120(1)
+  stfd 8, -128(1)
+  stfd 9, -136(1)
+  stfd 10, -144(1)
+  stfd 11, -152(1)
+  stfd 12, -160(1)
+  stfd 13, -168(1)
+
+  // TODO: also save Altivec registers
+
+  stdu 1, -256(1)
+
+  .cfi_def_cfa_offset 256
+  .cfi_offset r3, -8
+  .cfi_offset r4, -16
+  .cfi_offset r5, -24
+  .cfi_offset r6, -32
+  .cfi_offset r7, -40
+  .cfi_offset r8, -48
+  .cfi_offset r9, -56
+  .cfi_offset r10, -64
+  .cfi_offset f1, -72
+  .cfi_offset f2, -80
+  .cfi_offset f3, -88
+  .cfi_offset f4, -96
+  .cfi_offset f5, -104
+  .cfi_offset f6, -112
+  .cfi_offset f7, -120
+  .cfi_offset f8, -128
+  .cfi_offset f9, -136
+  .cfi_offset f10, -144
+  .cfi_offset f11, -152
+  .cfi_offset f12, -160
+  .cfi_offset f13, -168
+
+  mr 3, 0
+
+  bl _${lib_suffix}_tramp_resolve
+  nop
+
+  mr 12, 3
+
+  addi 1, 1, 256
+  .cfi_def_cfa_offset 0
+
+  ld 3, -8(1)
+  ld 4, -16(1)
+  ld 5, -24(1)
+  ld 6, -32(1)
+  ld 7, -40(1)
+  ld 8, -48(1)
+  ld 9, -56(1)
+  ld 10, -64(1)
+
+  lfd 1, -72(1)
+  lfd 2, -80(1)
+  lfd 3, -88(1)
+  lfd 4, -96(1)
+  lfd 5, -104(1)
+  lfd 6, -112(1)
+  lfd 7, -120(1)
+  lfd 8, -128(1)
+  lfd 9, -136(1)
+  lfd 10, -144(1)
+  lfd 11, -152(1)
+  lfd 12, -160(1)
+  lfd 13, -168(1)
+
+  ld 0, 16(1)
+  mtlr 0
+
+  .cfi_restore r3
+  .cfi_restore r4
+  .cfi_restore r5
+  .cfi_restore r6
+  .cfi_restore r7
+  .cfi_restore r8
+  .cfi_restore r9
+  .cfi_restore r10
+  .cfi_restore f1
+  .cfi_restore f2
+  .cfi_restore f3
+  .cfi_restore f4
+  .cfi_restore f5
+  .cfi_restore f6
+  .cfi_restore f7
+  .cfi_restore f8
+  .cfi_restore f9
+  .cfi_restore f10
+  .cfi_restore f11
+  .cfi_restore f12
+  .cfi_restore f13
+
+  blr
+
+  .long 0
+  .quad 0
+
+  .cfi_endproc

--- a/third_party/implib/arch/powerpc64le/trampoline.S.tpl
+++ b/third_party/implib/arch/powerpc64le/trampoline.S.tpl
@@ -1,0 +1,76 @@
+/*
+ * Copyright 2024-2025 Yury Gribov
+ *
+ * The MIT License (MIT)
+ *
+ * Use of this source code is governed by MIT license that can be
+ * found in the LICENSE.txt file.
+ */
+
+  .globl $sym
+  .p2align 4
+  .type $sym, %function
+#ifndef IMPLIB_EXPORT_SHIMS
+  .hidden $sym
+#endif
+
+  // Force callers to save r2
+  .localentry $sym, 1
+
+$sym:
+  .cfi_startproc
+
+  // Get function address
+  mflr 11
+  bcl 20, 31, $$+4
+0:
+  mflr 12
+  mtlr 11
+  addi 12, 12, ($sym - 0b)
+
+  // Get TOC address
+  addis 2, 12, .TOC. - $sym@ha
+  addi 2, 2, .TOC. - $sym@l
+
+1:
+  // Load address
+  addis 12, 2, .LC0@toc@ha
+  ld 12, .LC0@toc@l(12)
+  ld 12, $offset(12)
+
+  cmpdi 12, 0
+  beq 3f
+
+2: // "Fast" path
+
+  mtctr 12
+  bctr
+
+3: // Slow path
+
+  mflr 0
+  std 0, 16(1)
+
+  li 0, $number
+  std 0, -8(1)
+
+  stdu 1, -48(1)
+  .cfi_def_cfa_offset 48
+  .cfi_offset lr, 16
+
+  bl _${lib_suffix}_save_regs_and_resolve
+  nop
+
+  addi 1, 1, 48
+  .cfi_def_cfa_offset 0
+
+  ld 0, 16(1)
+  mtlr 0
+  .cfi_restore lr
+
+  b 2b
+
+  .long 0
+  .quad 0
+
+  .cfi_endproc

--- a/third_party/implib/arch/riscv64/config.ini
+++ b/third_party/implib/arch/riscv64/config.ini
@@ -1,0 +1,3 @@
+[Arch]
+PointerSize = 8
+SymbolReloc = R_RISCV_64

--- a/third_party/implib/arch/riscv64/table.S.tpl
+++ b/third_party/implib/arch/riscv64/table.S.tpl
@@ -1,0 +1,128 @@
+/*
+ * Copyright 2024-2025 Yury Gribov
+ *
+ * The MIT License (MIT)
+ *
+ * Use of this source code is governed by MIT license that can be
+ * found in the LICENSE.txt file.
+ */
+
+  .section .note.GNU-stack,"",@progbits
+
+  .data
+
+  .globl _${lib_suffix}_tramp_table
+  .hidden _${lib_suffix}_tramp_table
+  .align 8
+_${lib_suffix}_tramp_table:
+  .zero $table_size
+
+  .text
+
+  .globl _${lib_suffix}_tramp_resolve
+  .hidden _${lib_suffix}_tramp_resolve
+
+  .globl _${lib_suffix}_save_regs_and_resolve
+  .hidden _${lib_suffix}_save_regs_and_resolve
+  .type _${lib_suffix}_save_regs_and_resolve, %function
+_${lib_suffix}_save_regs_and_resolve:
+  .cfi_startproc
+
+  // Slow path which calls dlsym, taken only on first call.
+  // Registers are saved according to "Procedure Call Standard for the Arm® 64-bit Architecture".
+  // For DWARF directives, read https://www.imperialviolet.org/2017/01/18/cfi.html.
+
+  // TODO: cfi_offset/cfi_restore
+
+  addi sp, sp, -144
+ .cfi_adjust_cfa_offset 144
+
+  sd ra, 0(sp)
+  .cfi_rel_offset ra, 0
+
+  sd a0, 8(sp)
+  .cfi_rel_offset a0, 8
+  sd a1, 16(sp)
+  .cfi_rel_offset a1, 16
+  sd a2, 24(sp)
+  .cfi_rel_offset a2, 24
+  sd a3, 32(sp)
+  .cfi_rel_offset a3, 32
+  sd a4, 40(sp)
+  .cfi_rel_offset a4, 40
+  sd a5, 48(sp)
+  .cfi_rel_offset a5, 48
+  sd a6, 56(sp)
+  .cfi_rel_offset a6, 56
+  sd a7, 64(sp)
+  .cfi_rel_offset a7, 64
+
+  fsd fa0, 72(sp)
+  .cfi_rel_offset fa0, 72
+  fsd fa1, 80(sp)
+  .cfi_rel_offset fa1, 80
+  fsd fa2, 88(sp)
+  .cfi_rel_offset fa2, 88
+  fsd fa3, 96(sp)
+  .cfi_rel_offset fa3, 96
+  fsd fa4, 104(sp)
+  .cfi_rel_offset fa4, 104
+  fsd fa5, 112(sp)
+  .cfi_rel_offset fa5, 112
+  fsd fa6, 120(sp)
+  .cfi_rel_offset fa6, 120
+  fsd fa7, 128(sp)
+  .cfi_rel_offset fa7, 128
+
+  ld a0, 144(sp)
+
+  // TODO: vector arguments
+
+  // Stack is aligned at 16 bytes
+
+  call _${lib_suffix}_tramp_resolve
+  mv t0, a0
+
+  fld fa7, 128(sp)
+  .cfi_restore fa7
+  fld fa6, 120(sp)
+  .cfi_restore fa6
+  fld fa5, 112(sp)
+  .cfi_restore fa5
+  fld fa4, 104(sp)
+  .cfi_restore fa4
+  fld fa3, 96(sp)
+  .cfi_restore fa3
+  fld fa2, 88(sp)
+  .cfi_restore fa2
+  fld fa1, 80(sp)
+  .cfi_restore fa1
+  fld fa0, 72(sp)
+  .cfi_restore fa0
+
+  ld a7, 64(sp)
+  .cfi_restore a7
+  ld a6, 56(sp)
+  .cfi_restore a6
+  ld a5, 48(sp)
+  .cfi_restore a5
+  ld a4, 40(sp)
+  .cfi_restore a4
+  ld a3, 32(sp)
+  .cfi_restore a3
+  ld a2, 24(sp)
+  .cfi_restore a2
+  ld a1, 16(sp)
+  .cfi_restore a1
+  ld a0, 8(sp)
+  .cfi_restore a0
+
+  ld ra, 0(sp)
+  .cfi_restore ra
+
+  addi sp, sp, 144
+  .cfi_def_cfa_offset 0
+
+  jr ra
+
+  .cfi_endproc

--- a/third_party/implib/arch/riscv64/trampoline.S.tpl
+++ b/third_party/implib/arch/riscv64/trampoline.S.tpl
@@ -1,0 +1,53 @@
+/*
+ * Copyright 2024-2025 Yury Gribov
+ *
+ * The MIT License (MIT)
+ *
+ * Use of this source code is governed by MIT license that can be
+ * found in the LICENSE.txt file.
+ */
+
+  .globl $sym
+  .p2align 4
+  .type $sym, %function
+#ifndef IMPLIB_EXPORT_SHIMS
+  .hidden $sym
+#endif
+$sym:
+  .cfi_startproc
+
+1:
+  // Load address
+
+  lla t0, _${lib_suffix}_tramp_table+$offset
+  ld t0, 0(t0)
+
+  beq t0, zero, 2f
+
+  // Fast path
+  jr t0
+
+2:
+  // Slow path
+
+  addi sp, sp, -16
+  .cfi_adjust_cfa_offset 16
+
+  sd ra, 8(sp)
+  .cfi_rel_offset ra, 8
+
+  li t0, $number
+  sd t0, 0(sp)
+
+  // TODO: cfi_offset/cfi_restore
+
+  call _${lib_suffix}_save_regs_and_resolve
+
+  ld ra, 8(sp)
+  .cfi_restore ra
+
+  addi sp, sp, 16
+  .cfi_def_cfa_offset 0
+
+  jr t0
+  .cfi_endproc

--- a/third_party/implib/arch/x86_64/config.ini
+++ b/third_party/implib/arch/x86_64/config.ini
@@ -1,0 +1,3 @@
+[Arch]
+PointerSize = 8
+SymbolReloc = R_X86_64_64

--- a/third_party/implib/arch/x86_64/table.S.tpl
+++ b/third_party/implib/arch/x86_64/table.S.tpl
@@ -1,0 +1,158 @@
+/*
+ * Copyright 2018-2025 Yury Gribov
+ *
+ * The MIT License (MIT)
+ *
+ * Use of this source code is governed by MIT license that can be
+ * found in the LICENSE.txt file.
+ */
+
+  .section .note.GNU-stack,"",@progbits
+
+  .data
+
+  .globl _${lib_suffix}_tramp_table
+  .hidden _${lib_suffix}_tramp_table
+  .align 8
+_${lib_suffix}_tramp_table:
+  .zero $table_size
+
+  .text
+
+  .globl _${lib_suffix}_tramp_resolve
+  .hidden _${lib_suffix}_tramp_resolve
+
+  .globl _${lib_suffix}_save_regs_and_resolve
+  .hidden _${lib_suffix}_save_regs_and_resolve
+  .type _${lib_suffix}_save_regs_and_resolve, %function
+_${lib_suffix}_save_regs_and_resolve:
+  .cfi_startproc
+
+#define PUSH_REG(reg) pushq %reg ; .cfi_adjust_cfa_offset 8; .cfi_rel_offset reg, 0
+#define POP_REG(reg) popq %reg ; .cfi_adjust_cfa_offset -8; .cfi_restore reg
+
+#define DEC_STACK(d) subq $$d, %rsp; .cfi_adjust_cfa_offset d
+#define INC_STACK(d) addq $$d, %rsp; .cfi_adjust_cfa_offset -d
+
+#define PUSH_MMX_REG(reg) DEC_STACK(8); movq %reg, (%rsp); .cfi_rel_offset reg, 0
+#define POP_MMX_REG(reg) movq (%rsp), %reg; .cfi_restore reg; INC_STACK(8)
+
+#define PUSH_XMM_REG(reg) DEC_STACK(16); movdqa %reg, (%rsp); .cfi_rel_offset reg, 0
+#define POP_XMM_REG(reg) movdqa (%rsp), %reg; .cfi_restore reg; INC_STACK(16)
+
+// TODO: cfi_offset/cfi_restore
+#define PUSH_YMM_REG(reg) DEC_STACK(32); vmovdqu %reg, (%rsp)
+#define POP_YMM_REG(reg) vmovdqu (%rsp), %reg; INC_STACK(32)
+
+// TODO: cfi_offset/cfi_restore
+#define PUSH_ZMM_REG(reg) DEC_STACK(64); vmovdqu32 %reg, (%rsp)
+#define POP_ZMM_REG(reg) vmovdqu32 (%rsp), %reg; INC_STACK(64)
+
+  // Slow path which calls dlsym, taken only on first call.
+  // All registers are stored to handle arbitrary calling conventions
+  // (except x87 FPU registers which do not have to be preserved).
+  // For Dwarf directives, read https://www.imperialviolet.org/2017/01/18/cfi.html.
+
+  .cfi_def_cfa_offset 8  // Return address
+
+  PUSH_REG(rdi)  // 16
+  mov 0x10(%rsp), %rdi
+  PUSH_REG(rbx)
+  PUSH_REG(rbx)  // 16
+  PUSH_REG(rcx)
+  PUSH_REG(rdx)  // 16
+  PUSH_REG(rbp)
+  PUSH_REG(rsi)  // 16
+  PUSH_REG(r8)
+  PUSH_REG(r9)  // 16
+  PUSH_REG(r10)
+  PUSH_REG(r11)  // 16
+  PUSH_REG(r12)
+  PUSH_REG(r13)  // 16
+  PUSH_REG(r14)
+  PUSH_REG(r15)  // 16
+
+  // Maybe use cpuid instead of macro to detect current vector size...
+#ifdef __AVX512F__
+  PUSH_ZMM_REG(zmm0)
+  PUSH_ZMM_REG(zmm1)
+  PUSH_ZMM_REG(zmm2)
+  PUSH_ZMM_REG(zmm3)
+  PUSH_ZMM_REG(zmm4)
+  PUSH_ZMM_REG(zmm5)
+  PUSH_ZMM_REG(zmm6)
+  PUSH_ZMM_REG(zmm7)
+#elif defined __AVX__
+  PUSH_YMM_REG(ymm0)
+  PUSH_YMM_REG(ymm1)
+  PUSH_YMM_REG(ymm2)
+  PUSH_YMM_REG(ymm3)
+  PUSH_YMM_REG(ymm4)
+  PUSH_YMM_REG(ymm5)
+  PUSH_YMM_REG(ymm6)
+  PUSH_YMM_REG(ymm7)
+#elif defined __SSE__
+  PUSH_XMM_REG(xmm0)
+  PUSH_XMM_REG(xmm1)
+  PUSH_XMM_REG(xmm2)
+  PUSH_XMM_REG(xmm3)
+  PUSH_XMM_REG(xmm4)
+  PUSH_XMM_REG(xmm5)
+  PUSH_XMM_REG(xmm6)
+  PUSH_XMM_REG(xmm7)
+#endif
+
+  // MMX registers are not used to pass arguments so we do not save them
+
+  // Stack is just 8-byte aligned but callee will re-align to 16
+  call _${lib_suffix}_tramp_resolve
+
+#ifdef __AVX512F__
+  POP_ZMM_REG(zmm7)
+  POP_ZMM_REG(zmm6)
+  POP_ZMM_REG(zmm5)
+  POP_ZMM_REG(zmm4)
+  POP_ZMM_REG(zmm3)
+  POP_ZMM_REG(zmm2)
+  POP_ZMM_REG(zmm1)
+  POP_ZMM_REG(zmm0)  // 16
+#elif defined __AVX__
+  POP_YMM_REG(ymm7)
+  POP_YMM_REG(ymm6)
+  POP_YMM_REG(ymm5)
+  POP_YMM_REG(ymm4)
+  POP_YMM_REG(ymm3)
+  POP_YMM_REG(ymm2)
+  POP_YMM_REG(ymm1)
+  POP_YMM_REG(ymm0)  // 16
+#elif defined __SSE__
+  POP_XMM_REG(xmm7)
+  POP_XMM_REG(xmm6)
+  POP_XMM_REG(xmm5)
+  POP_XMM_REG(xmm4)
+  POP_XMM_REG(xmm3)
+  POP_XMM_REG(xmm2)
+  POP_XMM_REG(xmm1)
+  POP_XMM_REG(xmm0)  // 16
+#endif
+
+  POP_REG(r15)
+  POP_REG(r14)  // 16
+  POP_REG(r13)
+  POP_REG(r12)  // 16
+  POP_REG(r11)
+  POP_REG(r10)  // 16
+  POP_REG(r9)
+  POP_REG(r8)  // 16
+  POP_REG(rsi)
+  POP_REG(rbp)  // 16
+  POP_REG(rdx)
+  POP_REG(rcx)  // 16
+  POP_REG(rbx)
+  POP_REG(rbx)  // 16
+  POP_REG(rdi)
+
+  ret
+
+  .cfi_endproc
+

--- a/third_party/implib/arch/x86_64/trampoline.S.tpl
+++ b/third_party/implib/arch/x86_64/trampoline.S.tpl
@@ -1,0 +1,34 @@
+/*
+ * Copyright 2018-2025 Yury Gribov
+ *
+ * The MIT License (MIT)
+ *
+ * Use of this source code is governed by MIT license that can be
+ * found in the LICENSE.txt file.
+ */
+
+  .globl $sym
+  .p2align 4
+  .type $sym, %function
+#ifndef IMPLIB_EXPORT_SHIMS
+  .hidden $sym
+#endif
+$sym:
+  .cfi_startproc
+  .cfi_def_cfa_offset 8  // Return address
+  // Intel opt. manual says to
+  // "make the fall-through code following a conditional branch be the likely target for a branch with a forward target"
+  // to hint static predictor.
+  cmpq $$0, _${lib_suffix}_tramp_table+$offset(%rip)
+  je 2f
+1:
+  jmp *_${lib_suffix}_tramp_table+$offset(%rip)
+2:
+  pushq $$$number
+  .cfi_adjust_cfa_offset 8
+  call _${lib_suffix}_save_regs_and_resolve
+  addq $$8, %rsp
+  .cfi_adjust_cfa_offset -8
+  jmp *%rax
+  .cfi_endproc
+

--- a/third_party/implib/implib-gen.py
+++ b/third_party/implib/implib-gen.py
@@ -1,0 +1,831 @@
+#!/usr/bin/env python3
+
+# Copyright 2017-2025 Yury Gribov
+#
+# The MIT License (MIT)
+#
+# Use of this source code is governed by MIT license that can be
+# found in the LICENSE.txt file.
+
+"""
+Generates static import library for POSIX shared library
+"""
+
+import sys
+import os
+import os.path
+import re
+import subprocess
+import argparse
+import string
+import configparser
+
+me = os.path.basename(__file__)
+root = os.path.dirname(__file__)
+
+
+def warn(msg):
+    """Emits a nicely-decorated warning."""
+    sys.stderr.write(f"{me}: warning: {msg}\n")
+
+
+def error(msg):
+    """Emits a nicely-decorated error and exits."""
+    sys.stderr.write(f"{me}: error: {msg}\n")
+    sys.exit(1)
+
+
+def run(args, stdin=""):
+    """Runs external program and aborts on error."""
+    env = os.environ.copy()
+    # Force English language
+    env["LC_ALL"] = "c"
+    try:
+        del env["LANG"]
+    except KeyError:
+        pass
+    with subprocess.Popen(
+        args,
+        stdin=subprocess.PIPE,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+        env=env,
+    ) as p:
+        out, err = p.communicate(input=stdin.encode("utf-8"))
+    out = out.decode("utf-8")
+    err = err.decode("utf-8")
+    if p.returncode != 0 or err:
+        error(f"{args[0]} failed with retcode {p.returncode}:\n{err}")
+    return out, err
+
+
+def is_binary_file(filename):
+    """Check if file is an ELF."""
+    cmd = ["readelf", "-d", filename]
+    with subprocess.Popen(
+        cmd,
+        stdin=subprocess.DEVNULL,
+        stdout=subprocess.DEVNULL,
+        stderr=subprocess.DEVNULL,
+    ) as p:
+        p.communicate()
+    return p.returncode == 0
+
+
+def make_toc(words, renames=None):
+    "Make an mapping of words to their indices in list"
+    renames = renames or {}
+    toc = {}
+    for i, n in enumerate(words):
+        name = renames.get(n, n)
+        toc[i] = name
+    return toc
+
+
+def parse_row(words, toc, hex_keys):
+    "Make a mapping from column names to values"
+    vals = {k: (words[i] if i < len(words) else "") for i, k in toc.items()}
+    for k in hex_keys:
+        if vals[k]:
+            vals[k] = int(vals[k], 16)
+    return vals
+
+
+def collect_syms(f):
+    """Collect ELF dynamic symtab."""
+
+    # --dyn-syms does not always work for some reason so dump all symtabs
+    out, _ = run(["readelf", "-sW", f])
+
+    toc = None
+    syms = []
+    syms_set = set()
+
+    for line in out.splitlines():
+        line = line.strip()
+
+        # Strip out strange markers in powerpc64le ELFs
+        line = re.sub(r"\[<localentry>: [0-9]+\]", "", line)
+
+        if not line:
+            # Next symtab
+            toc = None
+            continue
+
+        words = re.split(r" +", line)
+
+        if line.startswith("Num"):  # Header?
+            if toc is not None:
+                error("multiple headers in output of readelf")
+            # Colons are different across readelf versions so get rid of them.
+            toc = make_toc(map(lambda n: n.replace(":", ""), words))
+        elif toc is not None:
+            sym = parse_row(words, toc, ["Value"])
+            name = sym["Name"]
+            if not name:
+                continue
+            if name in syms_set:
+                continue
+            syms_set.add(name)
+            sym["Size"] = int(
+                sym["Size"], 0
+            )  # Readelf is inconsistent about Size format
+            if "@" in name:
+                sym["Default"] = "@@" in name
+                name, ver = re.split(r"@+", name)
+                sym["Name"] = name
+                sym["Version"] = ver
+            else:
+                sym["Default"] = True
+                sym["Version"] = None
+            syms.append(sym)
+
+    if toc is None:
+        error(f"failed to analyze symbols in {f}")
+
+    return syms
+
+
+def collect_def_exports(filename):
+    """Reads exported symbols from .def file."""
+
+    syms = []
+
+    with open(filename, "r") as f:
+        lines = f.readlines()
+    lines.reverse()
+
+    while lines:
+        line = lines.pop().strip()
+
+        if line != "EXPORTS":
+            continue
+
+        while lines:
+            line = lines.pop()
+
+            if re.match(r"^\s*;", line):  # Comment
+                continue
+
+            # TODO: support renames
+            m = re.match(r"^\s+([A-Za-z0-9_]+)\s*$", line)
+            if m is None:
+                lines.append(line)
+                break
+
+            sym = {
+                "Name": m[1],
+                "Bind": "GLOBAL",
+                "Type": "FUNC",
+                "Ndx": "0",
+                "Default": True,
+                "Version": None,
+                "Size": 0,
+            }
+            syms.append(sym)
+
+    if not syms:
+        warn(f"failed to locate symbols in {filename}")
+
+    return syms
+
+
+def collect_relocs(f):
+    """Collect ELF dynamic relocs."""
+
+    out, _ = run(["readelf", "-rW", f])
+
+    toc = None
+    rels = []
+    for line in out.splitlines():
+        line = line.strip()
+        if not line:
+            toc = None
+            continue
+        if line == "There are no relocations in this file.":
+            return []
+        if re.match(r"^\s*Type[0-9]:", line):  # Spurious lines for MIPS
+            continue
+        if re.match(r"^\s*Offset", line):  # Header?
+            if toc is not None:
+                error("multiple headers in output of readelf")
+            words = re.split(r"\s\s+", line)  # "Symbol's Name + Addend"
+            toc = make_toc(words)
+        elif re.match(r"^\s*r_offset", line):  # FreeBSD header?
+            if toc is not None:
+                error("multiple headers in output of readelf")
+            words = re.split(r"\s\s+", line)  # "st_name + r_addend"
+            toc = make_toc(words)
+            rename = {
+                "r_offset": "Offset",
+                "r_info": "Info",
+                "r_type": "Type",
+                "st_value": "Symbol's Value",
+                "st_name + r_addend": "Symbol's Name + Addend",
+            }
+            toc = {idx: rename[name] for idx, name in toc.items()}
+        elif toc is not None:
+            line = re.sub(r" \+ ", "+", line)
+            words = re.split(r"\s+", line)
+            rel = parse_row(words, toc, ["Offset", "Info"])
+            rels.append(rel)
+            # Split symbolic representation
+            sym_name = "Symbol's Name + Addend"
+            if sym_name not in rel and "Symbol's Name" in rel:
+                # Adapt to different versions of readelf
+                rel[sym_name] = rel["Symbol's Name"] + "+0"
+            if rel[sym_name]:
+                p = rel[sym_name].split("+")
+                if len(p) == 1:
+                    p = ["", p[0]]
+                rel[sym_name] = (p[0], int(p[1], 16))
+
+    if toc is None:
+        error(f"failed to analyze relocations in {f}")
+
+    return rels
+
+
+def collect_sections(f):
+    """Collect section info from ELF."""
+
+    out, _ = run(["readelf", "-SW", f])
+
+    toc = None
+    sections = []
+    for line in out.splitlines():
+        line = line.strip()
+        if not line:
+            continue
+        line = re.sub(r"\[\s+", "[", line)
+        words = re.split(r" +", line)
+        if line.startswith("[Nr]"):  # Header?
+            if toc is not None:
+                error("multiple headers in output of readelf")
+            toc = make_toc(words, {"Addr": "Address"})
+        elif line.startswith("[") and toc is not None:
+            sec = parse_row(words, toc, ["Address", "Off", "Size"])
+            if "A" in sec["Flg"]:  # Allocatable section?
+                sections.append(sec)
+
+    if toc is None:
+        error(f"failed to analyze sections in {f}")
+
+    return sections
+
+
+def read_unrelocated_data(input_name, syms, secs):
+    """Collect unrelocated data from ELF."""
+    data = {}
+    with open(input_name, "rb") as f:
+
+        def is_symbol_in_section(sym, sec):
+            sec_end = sec["Address"] + sec["Size"]
+            is_start_in_section = sec["Address"] <= sym["Value"] < sec_end
+            is_end_in_section = sym["Value"] + sym["Size"] <= sec_end
+            return is_start_in_section and is_end_in_section
+
+        for name, s in sorted(syms.items(), key=lambda s: s[1]["Value"]):
+            # TODO: binary search (bisect)
+            sec = [sec for sec in secs if is_symbol_in_section(s, sec)]
+            if len(sec) != 1:
+                error(
+                    f"failed to locate section for interval [{s['Value']:x}, {s['Value'] + s['Size']:x})"
+                )
+            sec = sec[0]
+            f.seek(sec["Off"])
+            data[name] = f.read(s["Size"])
+    return data
+
+
+def collect_relocated_data(syms, bites, rels, ptr_size, reloc_types):
+    """Identify relocations for each symbol"""
+    data = {}
+    for name, s in sorted(syms.items()):
+        b = bites.get(name)
+        assert b is not None
+        if s["Demangled Name"].startswith("typeinfo name"):
+            data[name] = [("byte", int(x)) for x in b]
+            continue
+        data[name] = []
+        for i in range(0, len(b), ptr_size):
+            val = int.from_bytes(
+                b[i * ptr_size : (i + 1) * ptr_size], byteorder="little"
+            )
+            data[name].append(("offset", val))
+        start = s["Value"]
+        finish = start + s["Size"]
+        # TODO: binary search (bisect)
+        for rel in rels:
+            if rel["Type"] in reloc_types and start <= rel["Offset"] < finish:
+                i = (rel["Offset"] - start) // ptr_size
+                assert i < len(data[name])
+                data[name][i] = "reloc", rel
+    return data
+
+
+def generate_vtables(cls_tables, cls_syms, cls_data):
+    """Generate code for vtables"""
+    c_types = {"reloc": "const void *", "byte": "unsigned char", "offset": "size_t"}
+
+    ss = []
+    ss.append(
+        """\
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+"""
+    )
+
+    # Print externs
+
+    printed = set()
+    for name, data in sorted(cls_data.items()):
+        for typ, val in data:
+            if typ != "reloc":
+                continue
+            sym_name, addend = val["Symbol's Name + Addend"]
+            sym_name = re.sub(r"@.*", "", sym_name)  # Can we pin version in C?
+            if sym_name not in cls_syms and sym_name not in printed:
+                ss.append(
+                    f"""\
+extern const char {sym_name}[];
+
+"""
+                )
+
+    # Collect variable infos
+
+    code_info = {}
+
+    for name, s in sorted(cls_syms.items()):
+        data = cls_data[name]
+        if s["Demangled Name"].startswith("typeinfo name"):
+            declarator = "const unsigned char %s[]"
+        else:
+            field_types = (
+                f"{c_types[typ]} field_{i};" for i, (typ, _) in enumerate(data)
+            )
+            declarator = "const struct { %s } %%s" % " ".join(
+                field_types
+            )  # pylint: disable=C0209  # consider-using-f-string
+        vals = []
+        for typ, val in data:
+            if typ != "reloc":
+                vals.append(str(val) + "UL")
+            else:
+                sym_name, addend = val["Symbol's Name + Addend"]
+                sym_name = re.sub(r"@.*", "", sym_name)  # Can we pin version in C?
+                vals.append(f"(const char *)&{sym_name} + {addend}")
+        code_info[name] = (
+            declarator,
+            "{ %s }" % ", ".join(vals),
+        )  # pylint: disable= C0209  # consider-using-f-string
+
+    # Print declarations
+
+    for name, (decl, _) in sorted(code_info.items()):
+        type_name = name + "_type"
+        type_decl = decl % type_name
+        ss.append(
+            f"""\
+typedef {type_decl};
+extern __attribute__((weak)) {type_name} {name};
+"""
+        )
+
+    # Print definitions
+
+    for name, (_, init) in sorted(code_info.items()):
+        type_name = name + "_type"
+        ss.append(
+            f"""\
+const {type_name} {name} = {init};
+"""
+        )
+
+    ss.append(
+        """\
+#ifdef __cplusplus
+}  // extern "C"
+#endif
+"""
+    )
+
+    return "".join(ss)
+
+
+def read_soname(f):
+    """Read ELF's SONAME."""
+
+    out, _ = run(["readelf", "-d", f])
+
+    for line in out.splitlines():
+        line = line.strip()
+        if not line:
+            continue
+        # 0x000000000000000e (SONAME)             Library soname: [libndp.so.0]
+        soname_match = re.search(r"\(SONAME\).*\[(.+)\]", line)
+        if soname_match is not None:
+            return soname_match[1]
+
+    return None
+
+
+def read_library_name(filename):
+    """Read library name from .def file."""
+
+    with open(filename, "r") as f:
+        for line in f.readlines():
+            line = line.strip()
+            m = re.match(r"^(?:LIBRARY|NAME)\s+([A-Za-z0-9_.\-]+)$", line)
+            if m is not None:
+                return m[1]
+
+    return None
+
+
+def main():
+    """Driver function"""
+    parser = argparse.ArgumentParser(
+        description="Generate wrappers for shared library functions.",
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+        epilog=f"""\
+Examples:
+  $ python3 {me} /usr/lib/x86_64-linux-gnu/libaccountsservice.so.0
+  Generating libaccountsservice.so.0.tramp.S...
+  Generating libaccountsservice.so.0.init.c...
+""",
+    )
+
+    parser.add_argument(
+        "library",
+        metavar="LIB",
+        help="Library to be wrapped (or .def file with list of functions).",
+    )
+    parser.add_argument(
+        "--verbose", "-v", help="Print diagnostic info", action="count", default=0
+    )
+    parser.add_argument(
+        "--dlopen",
+        help="Emit dlopen call (default)",
+        dest="dlopen",
+        action="store_true",
+        default=True,
+    )
+    parser.add_argument(
+        "--no-dlopen",
+        help="Do not emit dlopen call (user must load/unload library himself)",
+        dest="dlopen",
+        action="store_false",
+    )
+    parser.add_argument(
+        "--dlopen-callback",
+        help="Call user-provided custom callback to load library instead of dlopen",
+        default="",
+    )
+    parser.add_argument(
+        "--dlsym-callback",
+        help="Call user-provided custom callback to resolve a symbol, "
+        "instead of dlsym",
+        default="",
+    )
+    parser.add_argument(
+        "--library-load-name",
+        help="Use custom name for dlopened library (default is SONAME)",
+    )
+    parser.add_argument(
+        "--lazy-load",
+        help="Load library on first call to any of it's functions (default)",
+        dest="lazy_load",
+        action="store_true",
+        default=True,
+    )
+    parser.add_argument(
+        "--no-lazy-load",
+        help="Load library at program start",
+        dest="lazy_load",
+        action="store_false",
+    )
+    parser.add_argument(
+        "--thread-safe",
+        help="Ensure thread-safety (default)",
+        dest="thread_safe",
+        action="store_true",
+        default=True,
+    )
+    parser.add_argument(
+        "--no-thread-safe",
+        help="Do not ensure thread-safety",
+        dest="thread_safe",
+        action="store_false",
+    )
+    parser.add_argument(
+        "--vtables",
+        help="Intercept virtual tables (EXPERIMENTAL)",
+        dest="vtables",
+        action="store_true",
+        default=False,
+    )
+    parser.add_argument(
+        "--no-vtables",
+        help="Do not intercept virtual tables (default)",
+        dest="vtables",
+        action="store_false",
+    )
+    parser.add_argument(
+        "--no-weak-symbols",
+        help="Don't bind weak symbols",
+        dest="no_weak_symbols",
+        action="store_true",
+        default=False,
+    )
+    parser.add_argument(
+        "--target",
+        help="Target platform triple e.g. x86_64-unknown-linux-gnu or arm-none-eabi "
+        "(atm x86_64, i[0-9]86, arm/armhf/armeabi, aarch64/armv8, "
+        "mips/mipsel, mips64/mip64el, e2k, powerpc64/powerpc64le, "
+        "riscv64 are supported)",
+        default=os.uname()[-1],
+    )
+    parser.add_argument(
+        "--symbol-list",
+        help="Path to file with symbols that should be present in wrapper "
+        "(all by default)",
+    )
+    parser.add_argument(
+        "--symbol-prefix",
+        metavar="PFX",
+        help="Prefix wrapper symbols with PFX",
+        default="",
+    )
+    parser.add_argument(
+        "-q", "--quiet", help="Do not print progress info", action="store_true"
+    )
+    parser.add_argument(
+        "--outdir", "-o", help="Path to create wrapper at", default="./"
+    )
+
+    args = parser.parse_args()
+
+    input_name = args.library
+    verbose = args.verbose
+    dlopen_callback = args.dlopen_callback
+    dlsym_callback = args.dlsym_callback
+    dlopen = args.dlopen
+    lazy_load = args.lazy_load
+    thread_safe = args.thread_safe
+    if args.target.startswith("arm"):
+        target = "arm"  # Handle armhf-..., armel-...
+    elif re.match(r"^i[0-9]86", args.target):
+        target = "i386"
+    elif args.target.startswith("amd64"):
+        target = "x86_64"
+    elif args.target.startswith("mips64"):
+        target = "mips64"  # Handle mips64-..., mips64el-..., mips64le-...
+    elif args.target.startswith("mips"):
+        target = "mips"  # Handle mips-..., mipsel-..., mipsle-...
+    elif args.target.startswith("ppc64le"):
+        target = "powerpc64le"
+    elif args.target.startswith("ppc64"):
+        target = "powerpc64"
+    elif args.target.startswith("rv64"):
+        target = "riscv64"
+    else:
+        target = args.target.split("-")[0]
+    quiet = args.quiet
+    outdir = args.outdir
+
+    if not os.path.exists(outdir):
+        os.makedirs(outdir)
+
+    if args.symbol_list is None:
+        funs = None
+    else:
+        with open(args.symbol_list, "r") as f:
+            funs = []
+            for line in re.split(r"\r?\n", f.read()):
+                line = re.sub(r"#.*", "", line)
+                line = line.strip()
+                if line:
+                    funs.append(line)
+
+    binary = is_binary_file(input_name)
+    stem = os.path.basename(input_name)
+    if not binary:
+        stem = re.sub(r"\.def$", "", stem)
+
+    if args.library_load_name is not None:
+        load_name = args.library_load_name
+    elif binary:
+        load_name = read_soname(input_name)
+        load_name = load_name or stem
+    else:
+        load_name = read_library_name(input_name)
+        load_name = load_name or stem
+
+    # Collect target info
+
+    target_dir = os.path.join(root, "arch", target)
+
+    if not os.path.exists(target_dir):
+        error(f"unknown architecture '{target}'")
+
+    cfg = configparser.ConfigParser(inline_comment_prefixes=";")
+    cfg.read(target_dir + "/config.ini")
+
+    ptr_size = int(cfg["Arch"]["PointerSize"])
+    symbol_reloc_types = set(re.split(r"\s*,\s*", cfg["Arch"]["SymbolReloc"]))
+
+    def is_exported(s):
+        conditions = [
+            s["Bind"] != "LOCAL",
+            s["Type"] != "NOTYPE",
+            s["Ndx"] != "UND",
+            s["Name"] not in ["", "_init", "_fini"],
+        ]
+        if args.no_weak_symbols:
+            conditions.append(s["Bind"] != "WEAK")
+        return all(conditions)
+
+    if binary:
+        syms = collect_syms(input_name)
+    else:
+        syms = collect_def_exports(input_name)
+
+    # Also collected demangled names
+    if syms:
+        out, _ = run(["c++filt"], "\n".join((sym["Name"] for sym in syms)))
+        out = out.rstrip("\n")  # Some c++filts append newlines at the end
+        for i, name in enumerate(out.split("\n")):
+            syms[i]["Demangled Name"] = name
+
+    syms = list(filter(is_exported, syms))
+
+    def is_data_symbol(s):
+        return (
+            s["Type"] == "OBJECT"
+            # Allow vtables if --vtables is on
+            and not (" for " in s["Demangled Name"] and args.vtables)
+        )
+
+    exported_data = [s["Name"] for s in syms if is_data_symbol(s)]
+    if exported_data:
+        # TODO: we can generate wrappers for const data without relocations
+        # (or only code relocations)
+        warn(
+            f"library '{input_name}' contains data symbols which won't be intercepted: "
+            + ", ".join(exported_data)
+        )
+
+    # Collect functions
+    # TODO: warn if user-specified functions are missing
+
+    orig_funs = filter(lambda s: s["Type"] == "FUNC", syms)
+
+    all_funs = set()
+    warn_versioned = False
+    for s in orig_funs:
+        if not s["Default"]:
+            # TODO: support versions
+            if not warn_versioned:
+                warn(f"library {input_name} contains versioned symbols which are NYI")
+                warn_versioned = True
+            if verbose:
+                print(f"Skipping versioned symbol {s['Name']}")
+            continue
+        all_funs.add(s["Name"])
+
+    if funs is None:
+        funs = sorted(list(all_funs))
+        if not funs and not quiet:
+            warn(f"no public functions were found in {input_name}")
+    else:
+        missing_funs = [name for name in funs if name not in all_funs]
+        if missing_funs:
+            warn(
+                "some user-specified functions are not present in library: "
+                + ", ".join(missing_funs)
+            )
+        funs = [name for name in funs if name in all_funs]
+
+    if verbose:
+        print("Exported functions:")
+        for i, fun in enumerate(funs):
+            print(f"  {i}: {fun}")
+
+    # Collect vtables
+
+    if args.vtables:
+        if not binary:
+            error("vtables not supported for .def files")
+
+        cls_tables = {}
+        cls_syms = {}
+
+        for s in syms:
+            m = re.match(
+                r"^(vtable|typeinfo|typeinfo name) for (.*)", s["Demangled Name"]
+            )
+            if m is not None and is_exported(s):
+                typ, cls = m.groups()
+                name = s["Name"]
+                cls_tables.setdefault(cls, {})[typ] = name
+                cls_syms[name] = s
+
+        if verbose:
+            print("Exported classes:")
+            for cls, _ in sorted(cls_tables.items()):
+                print(f"  {cls}")
+
+        secs = collect_sections(input_name)
+        if verbose:
+            print("Sections:")
+            for sec in secs:
+                print(
+                    f"  {sec['Name']}: [{sec['Address']:x}, {sec['Address'] + sec['Size']:x}), "
+                    f"at {sec['Off']:x}"
+                )
+
+        bites = read_unrelocated_data(input_name, cls_syms, secs)
+
+        rels = collect_relocs(input_name)
+        if verbose:
+            print("Relocs:")
+            for rel in rels:
+                sym_add = rel["Symbol's Name + Addend"]
+                print(f"  {rel['Offset']}: {sym_add}")
+
+        cls_data = collect_relocated_data(
+            cls_syms, bites, rels, ptr_size, symbol_reloc_types
+        )
+        if verbose:
+            print("Class data:")
+            for name, data in sorted(cls_data.items()):
+                demangled_name = cls_syms[name]["Demangled Name"]
+                print(f"  {name} ({demangled_name}):")
+                for typ, val in data:
+                    print(
+                        "    "
+                        + str(val if typ != "reloc" else val["Symbol's Name + Addend"])
+                    )
+
+    # Generate assembly code
+
+    suffix = stem
+    lib_suffix = re.sub(r"[^a-zA-Z_0-9]+", "_", suffix)
+
+    tramp_file = f"{suffix}.tramp.S"
+    with open(os.path.join(outdir, tramp_file), "w") as f:
+        if not quiet:
+            print(f"Generating {tramp_file}...")
+        with open(target_dir + "/table.S.tpl", "r") as t:
+            table_text = string.Template(t.read()).substitute(
+                lib_suffix=lib_suffix, table_size=ptr_size * (len(funs) + 1)
+            )
+        f.write(table_text)
+
+        with open(target_dir + "/trampoline.S.tpl", "r") as t:
+            tramp_tpl = string.Template(t.read())
+
+        for i, name in enumerate(funs):
+            tramp_text = tramp_tpl.substitute(
+                lib_suffix=lib_suffix,
+                sym=args.symbol_prefix + name,
+                offset=i * ptr_size,
+                number=i,
+            )
+            f.write(tramp_text)
+
+    # Generate C code
+
+    init_file = f"{suffix}.init.c"
+    with open(os.path.join(outdir, init_file), "w") as f:
+        if not quiet:
+            print(f"Generating {init_file}...")
+        with open(os.path.join(root, "arch/common/init.c.tpl"), "r") as t:
+            if funs:
+                sym_names = ",\n  ".join(f'"{name}"' for name in funs) + ","
+            else:
+                sym_names = ""
+            init_text = string.Template(t.read()).substitute(
+                lib_suffix=lib_suffix,
+                load_name=load_name,
+                dlopen_callback=dlopen_callback,
+                dlsym_callback=dlsym_callback,
+                has_dlopen_callback=int(bool(dlopen_callback)),
+                has_dlsym_callback=int(bool(dlsym_callback)),
+                no_dlopen=int(not dlopen),
+                lazy_load=int(lazy_load),
+                thread_safe=int(thread_safe),
+                sym_names=sym_names,
+            )
+            f.write(init_text)
+        if args.vtables:
+            vtable_text = generate_vtables(cls_tables, cls_syms, cls_data)
+            f.write(vtable_text)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- vendor Implib.so under `third_party/implib` and mark it vendored/no-diff with `.gitattributes`
- generate CUDA runtime shim objects from the vendored Implib.so tool
- link CUDA ops with `CUDA_RUNTIME_LIBRARY=None` and compile the cudart shim directly into `libdeepmd_gnn.so`
- keep the wheel/package layout to a single OP shared library while avoiding direct `DT_NEEDED` on `libcudart.so.12`

## Verification
- built CUDA ops with CPU PyTorch + nvcc
- confirmed installed package and wheel contain only `deepmd_gnn/lib/libdeepmd_gnn.so`
- confirmed `readelf -d` has no direct `NEEDED libcudart.so.12`, `libtorch_cuda.so`, or extra cudart shim library
- built a wheel and ran the existing `auditwheel repair` command
- loaded the wheel library and ran CPU `edge_index`
- simulated missing `libcudart.so.12`; CPU load and CPU `edge_index` still pass