### PR TITLE
feat: add pretrained MACE property descriptor

### DIFF
--- a/README.md
+++ b/README.md
@@ -129,7 +129,7 @@ DeePMD property model. See
   "type_map": ["H", "O"],
   "descriptor": {
     "type": "mace",
-    "model_path": "./trusted_scale_shift_mace.model",
+    "model_path": "./trusted_single_head_mace_mp_or_mpa.model",
     "sel": 64,
     "trainable": true
   },
@@ -145,13 +145,30 @@ DeePMD property model. See
 trusted source. The model-level `type_map` must exactly match the checkpoint's
 atomic-number ordering; reordered or subset maps are rejected. `sel` is an
 explicit DeePMD neighbor-list capacity and cannot be inferred from MACE.
+Official single-head MACE-MP-0/MPA-0 89-element checkpoints therefore require:
+
+```text
+["H", "He", "Li", "Be", "B", "C", "N", "O", "F", "Ne", "Na", "Mg",
+ "Al", "Si", "P", "S", "Cl", "Ar", "K", "Ca", "Sc", "Ti", "V", "Cr",
+ "Mn", "Fe", "Co", "Ni", "Cu", "Zn", "Ga", "Ge", "As", "Se", "Br",
+ "Kr", "Rb", "Sr", "Y", "Zr", "Nb", "Mo", "Tc", "Ru", "Rh", "Pd",
+ "Ag", "Cd", "In", "Sn", "Sb", "Te", "I", "Xe", "Cs", "Ba", "La",
+ "Ce", "Pr", "Nd", "Pm", "Sm", "Eu", "Gd", "Tb", "Dy", "Ho", "Er",
+ "Tm", "Yb", "Lu", "Hf", "Ta", "W", "Re", "Os", "Ir", "Pt", "Au",
+ "Hg", "Tl", "Pb", "Bi", "Po", "At", "Rn", "Fr", "Ra", "Ac"]
+```
 
 The descriptor returns only invariant even-scalar (`0e`) channels from the
 final MACE product layer. Its embedding, interaction, and product weights are
 trainable by default together with the DeePMD `PropertyFittingNet`; MACE atomic
 energies, energy readouts, scale/shift, and pair-repulsion terms do not seed
 the property head. Property-label mean and standard deviation remain DeePMD
-statistics.
+statistics. Generic single-head native `ScaleShiftMACE` architectures are
+reconstructed from the checkpoint, including independent first/later
+interaction classes, layer-dependent correlation, named heads, pair
+repulsion, and mixed final irreps. This covers compatible MACE-MP-0 and MPA-0
+checkpoints without changing the separate conservative MACE-OFF energy-model
+conversion path.
 
 This descriptor path currently supports only `dp --pt`. The `pt_expt`
 backend, cuEquivariance checkpoint conversion, MACE-MH/multi-head checkpoints,

--- a/README.md
+++ b/README.md
@@ -142,10 +142,13 @@ DeePMD property model. See
 ```
 
 `model_path` uses Python pickle loading, so only load checkpoints from a
-trusted source. The model-level `type_map` must exactly match the checkpoint's
-atomic-number ordering; reordered or subset maps are rejected. `sel` is an
-explicit DeePMD neighbor-list capacity and cannot be inferred from MACE.
-Official single-head MACE-MP-0/MPA-0 89-element checkpoints therefore require:
+trusted source. Neighbor statistics persist the inferred backbone architecture
+into the saved DeePMD checkpoint, so `dp test` and freeze no longer need the
+original `.model` file. The model-level `type_map` must exactly match the
+checkpoint's atomic-number ordering; reordered or subset maps are rejected.
+`sel` is an explicit DeePMD neighbor-list capacity and cannot be inferred from
+MACE. Official single-head MACE-MP-0/MPA-0 89-element checkpoints therefore
+require:
 
 ```text
 ["H", "He", "Li", "Be", "B", "C", "N", "O", "F", "Ne", "Na", "Mg",

--- a/README.md
+++ b/README.md
@@ -116,6 +116,48 @@ dp --pt freeze
 A frozen model file named `frozen_model.pth` will be generated. You can use it in the MD packages or other interfaces.
 For details, follow [DeePMD-kit documentation](https://docs.deepmodeling.com/projects/deepmd/en/latest/).
 
+### Pretrained MACE descriptors for properties
+
+The regular PyTorch backend can use a trusted native
+`mace.modules.ScaleShiftMACE` checkpoint as the descriptor of a standard
+DeePMD property model. See
+[`examples/property/mace/input.json`](examples/property/mace/input.json):
+
+```json
+"model": {
+  "type": "standard",
+  "type_map": ["H", "O"],
+  "descriptor": {
+    "type": "mace",
+    "model_path": "./trusted_scale_shift_mace.model",
+    "sel": 64,
+    "trainable": true
+  },
+  "fitting_net": {
+    "type": "property",
+    "property_name": "band_gap",
+    "task_dim": 1
+  }
+}
+```
+
+`model_path` uses Python pickle loading, so only load checkpoints from a
+trusted source. The model-level `type_map` must exactly match the checkpoint's
+atomic-number ordering; reordered or subset maps are rejected. `sel` is an
+explicit DeePMD neighbor-list capacity and cannot be inferred from MACE.
+
+The descriptor returns only invariant even-scalar (`0e`) channels from the
+final MACE product layer. Its embedding, interaction, and product weights are
+trainable by default together with the DeePMD `PropertyFittingNet`; MACE atomic
+energies, energy readouts, scale/shift, and pair-repulsion terms do not seed
+the property head. Property-label mean and standard deviation remain DeePMD
+statistics.
+
+This descriptor path currently supports only `dp --pt`. The `pt_expt`
+backend, cuEquivariance checkpoint conversion, MACE-MH/multi-head checkpoints,
+type-map subsets, MPI descriptor communication, LAMMPS deployment, and DPRc
+descriptor semantics are out of scope.
+
 ### Exporting MACE models with the PyTorch exportable backend
 
 MACE models can also be trained and frozen with DeePMD-kit's PyTorch exportable
@@ -357,3 +399,4 @@ about (for example in LAMMPS or AMBER).
 
 - [examples/water](examples/water)
 - [examples/dprc](examples/dprc)
+- [examples/property/mace](examples/property/mace)

--- a/deepmd_gnn/__init__.py
+++ b/deepmd_gnn/__init__.py
@@ -3,12 +3,16 @@
 import os
 
 from ._version import __version__
-from .argcheck import mace_model_args
+from .argcheck import (
+    mace_descriptor_args,
+    mace_model_args,
+)
 
 __email__ = "jinzhe.zeng@ustc.edu.cn"
 
 __all__ = [
     "__version__",
+    "mace_descriptor_args",
     "mace_model_args",
 ]
 

--- a/deepmd_gnn/argcheck.py
+++ b/deepmd_gnn/argcheck.py
@@ -1,7 +1,47 @@
 """Argument check for the MACE model."""
 
 from dargs import Argument
-from deepmd.utils.argcheck import model_args_plugin
+from deepmd.utils.argcheck import (
+    descrpt_args_plugin,
+    model_args_plugin,
+)
+
+
+@descrpt_args_plugin.register("mace")
+def mace_descriptor_args() -> Argument:
+    """Arguments for a pretrained MACE property descriptor."""
+    return Argument(
+        "mace",
+        dict,
+        [
+            Argument(
+                "sel",
+                int,
+                optional=False,
+                doc="Explicit mixed-type DeePMD neighbor-list capacity.",
+            ),
+            Argument(
+                "model_path",
+                str,
+                optional=False,
+                doc=(
+                    "Path to a trusted native mace.modules.ScaleShiftMACE "
+                    "pickle checkpoint."
+                ),
+            ),
+            Argument(
+                "trainable",
+                bool,
+                optional=True,
+                default=True,
+                doc="Whether to optimize the pretrained MACE backbone.",
+            ),
+        ],
+        doc=(
+            "PyTorch-only MACE descriptor exposing invariant 0e channels from "
+            "the final product layer."
+        ),
+    )
 
 
 @model_args_plugin.register("mace")

--- a/deepmd_gnn/argcheck.py
+++ b/deepmd_gnn/argcheck.py
@@ -23,10 +23,21 @@ def mace_descriptor_args() -> Argument:
             Argument(
                 "model_path",
                 str,
-                optional=False,
+                optional=True,
                 doc=(
                     "Path to a trusted native mace.modules.ScaleShiftMACE "
-                    "pickle checkpoint."
+                    "pickle checkpoint. Required for initialization; saved "
+                    "DeePMD checkpoints restore from the persisted config."
+                ),
+            ),
+            Argument(
+                "config",
+                dict,
+                optional=True,
+                doc=(
+                    "Inferred MACE backbone architecture persisted into the "
+                    "saved model definition so restoration does not reopen "
+                    "the native pickle."
                 ),
             ),
             Argument(

--- a/deepmd_gnn/mace_checkpoint.py
+++ b/deepmd_gnn/mace_checkpoint.py
@@ -4,6 +4,7 @@
 from __future__ import annotations
 
 from contextlib import contextmanager
+from copy import deepcopy
 from typing import TYPE_CHECKING, Any, TypedDict
 
 import torch
@@ -21,6 +22,9 @@ _DISTANCE_TRANSFORMS = {
     "SoftTransform": "Soft",
 }
 _RADIAL_BASES = {"BesselBasis": "bessel"}
+ALLOWED_MISSING_STATE_DICT_SUFFIXES = ("_zeroed",)
+_PLACEHOLDER_GATE = "silu"
+_PLACEHOLDER_MLP_IRREPS = "16x0e"
 
 
 class MaceCheckpointConfig(TypedDict):
@@ -92,21 +96,58 @@ def load_native_mace_checkpoint(
     return model.to(device)
 
 
+def persistable_checkpoint_config(
+    config: MaceCheckpointConfig | dict[str, Any],
+) -> dict[str, Any]:
+    """Return JSON-safe constructor metadata for a saved DeePMD model definition."""
+    return deepcopy(dict(config))
+
+
+def validate_mace_state_dict_load(load_result: object) -> None:
+    """Reject missing learned weights while keeping reconstructed derived buffers."""
+    missing_keys = list(getattr(load_result, "missing_keys", []))
+    unexpected_keys = list(getattr(load_result, "unexpected_keys", []))
+    disallowed_missing_keys = [
+        key
+        for key in missing_keys
+        if not key.endswith(ALLOWED_MISSING_STATE_DICT_SUFFIXES)
+    ]
+    if disallowed_missing_keys or unexpected_keys:
+        msg = (
+            "Failed to load MACE checkpoint into DeePMD-GNN wrapper. "
+            f"missing={disallowed_missing_keys}, unexpected={unexpected_keys}"
+        )
+        raise RuntimeError(msg)
+
+
 def _infer_gate(model: ScaleShiftMACE) -> str:
+    """Return a MACE constructor gate; placeholders are fine for unused readouts."""
     if not model.readouts:
         return "None"
     last_readout = model.readouts[-1]
     non_linearity = getattr(last_readout, "non_linearity", None)
+    if non_linearity is None:
+        return _PLACEHOLDER_GATE
     acts = getattr(non_linearity, "acts", None)
-    if acts is None or len(acts) != 1 or not hasattr(acts[0], "f"):
-        msg = "Unsupported MACE nonlinear readout structure"
-        raise ValueError(msg)
-    gate_fn = acts[0].f
+    if acts is None or len(acts) != 1:
+        return _PLACEHOLDER_GATE
+    gate_fn = getattr(acts[0], "f", None)
+    if gate_fn is None:
+        return "None"
     for name, candidate in gate_dict.items():
         if candidate is not None and candidate is gate_fn:
             return name
-    msg = f"Unsupported MACE gate function: {gate_fn}"
-    raise ValueError(msg)
+    return _PLACEHOLDER_GATE
+
+
+def _infer_mlp_irreps(model: ScaleShiftMACE) -> str:
+    """Return readout MLP irreps, or a placeholder when the last readout is linear."""
+    if not model.readouts:
+        return _PLACEHOLDER_MLP_IRREPS
+    mlp_irreps = getattr(model.readouts[-1], "hidden_irreps", None)
+    if mlp_irreps is None:
+        return _PLACEHOLDER_MLP_IRREPS
+    return str(mlp_irreps)
 
 
 def _infer_radial_mlp(model: ScaleShiftMACE) -> list[int]:
@@ -181,11 +222,6 @@ def inspect_native_mace_checkpoint(model: ScaleShiftMACE) -> MaceCheckpointConfi
         msg = f"Unsupported MACE radial basis: {radial_name}"
         raise ValueError(msg)
 
-    last_readout = model.readouts[-1]
-    mlp_irreps = getattr(last_readout, "hidden_irreps", None)
-    if mlp_irreps is None:
-        msg = "Checkpoint does not expose nonlinear readout hidden irreps"
-        raise ValueError(msg)
     scale = model.scale_shift.state_dict()["scale"].detach().cpu()
     if scale.numel() != 1:
         msg = f"Single-head MACE scale must be scalar, got shape {tuple(scale.shape)}"
@@ -227,7 +263,7 @@ def inspect_native_mace_checkpoint(model: ScaleShiftMACE) -> MaceCheckpointConfi
         ),
         "correlation": _infer_correlations(model),
         "gate": _infer_gate(model),
-        "MLP_irreps": str(mlp_irreps),
+        "MLP_irreps": _infer_mlp_irreps(model),
         "radial_type": _RADIAL_BASES[radial_name],
         "radial_MLP": _infer_radial_mlp(model),
         "std": float(scale.item()),
@@ -300,10 +336,13 @@ def build_mace_feature_backbone(
 
 
 __all__ = [
+    "ALLOWED_MISSING_STATE_DICT_SUFFIXES",
     "MaceCheckpointConfig",
     "MaceFeatureBackbone",
     "build_mace_feature_backbone",
     "inspect_native_mace_checkpoint",
     "load_native_mace_checkpoint",
+    "persistable_checkpoint_config",
     "temporary_default_dtype",
+    "validate_mace_state_dict_load",
 ]

--- a/deepmd_gnn/mace_checkpoint.py
+++ b/deepmd_gnn/mace_checkpoint.py
@@ -85,7 +85,11 @@ def load_native_mace_checkpoint(
             f"{model.__class__.__module__}.{model.__class__.__name__}"
         )
         raise TypeError(msg)
-    return model
+    # ``map_location`` remaps serialized storages, but e3nn TensorProduct
+    # checkpoints also contain compiled TorchScript submodules.  An explicit
+    # module migration is required to move their Wigner/CG constants; this is
+    # the same two-step loading sequence used by MACECalculator.
+    return model.to(device)
 
 
 def _infer_gate(model: ScaleShiftMACE) -> str:

--- a/deepmd_gnn/mace_checkpoint.py
+++ b/deepmd_gnn/mace_checkpoint.py
@@ -284,6 +284,22 @@ class MaceFeatureBackbone(torch.nn.Module):
         self.radial_embedding = model.radial_embedding
         self.interactions = model.interactions
         self.products = model.products
+        # Older native pickles predate MACE's zero-path flags. Derive exactly
+        # the same flags from their existing CG tensors before training saves
+        # state: Tester scripts a reconstructed model before a strict load, so
+        # deserialize()'s missing-buffer allowance cannot repair that workflow.
+        for product in self.products:
+            for contraction in product.symmetric_contractions.contractions:
+                correlation = int(contraction.correlation)
+                for order in range(1, correlation + 1):
+                    name = (
+                        "weights_max_zeroed"
+                        if order == correlation
+                        else f"weights_{order - 1}_zeroed"
+                    )
+                    if not hasattr(contraction, name):
+                        matrix = getattr(contraction, f"U_matrix_{order}")
+                        contraction.register_buffer(name, torch.all(matrix == 0))
         self.register_buffer("atomic_numbers", model.atomic_numbers.detach().clone())
 
 

--- a/deepmd_gnn/mace_checkpoint.py
+++ b/deepmd_gnn/mace_checkpoint.py
@@ -1,0 +1,305 @@
+# SPDX-License-Identifier: LGPL-3.0-or-later
+"""Generic native ``ScaleShiftMACE`` checkpoint support for descriptors."""
+
+from __future__ import annotations
+
+from contextlib import contextmanager
+from typing import TYPE_CHECKING, Any, TypedDict
+
+import torch
+from ase.data import chemical_symbols
+from e3nn import o3
+from mace.modules import ScaleShiftMACE, gate_dict, interaction_classes
+
+if TYPE_CHECKING:
+    from collections.abc import Iterator
+    from pathlib import Path
+
+_DISTANCE_TRANSFORMS = {
+    None: "None",
+    "AgnesiTransform": "Agnesi",
+    "SoftTransform": "Soft",
+}
+_RADIAL_BASES = {"BesselBasis": "bessel"}
+
+
+class MaceCheckpointConfig(TypedDict):
+    """Constructor state needed to rebuild a supported feature backbone."""
+
+    type_map: list[str]
+    r_max: float
+    num_radial_basis: int
+    num_cutoff_basis: int
+    max_ell: int
+    interaction_first: str
+    interaction: str
+    num_interactions: int
+    hidden_irreps: str
+    pair_repulsion: bool
+    apply_cutoff: bool
+    use_reduced_cg: bool
+    use_so3: bool
+    use_agnostic_product: bool
+    use_last_readout_only: bool
+    use_embedding_readout: bool
+    distance_transform: str
+    edge_irreps: str | None
+    use_edge_irreps_first: bool
+    correlation: list[int]
+    gate: str
+    MLP_irreps: str
+    radial_type: str
+    radial_MLP: list[int]
+    std: float
+    avg_num_neighbors: float
+    keep_last_layer_irreps: bool
+    heads: list[str] | None
+    source_dtype: str
+
+
+@contextmanager
+def temporary_default_dtype(dtype: torch.dtype) -> Iterator[None]:
+    """Temporarily set Torch's process-wide construction dtype."""
+    old_dtype = torch.get_default_dtype()
+    torch.set_default_dtype(dtype)
+    try:
+        yield
+    finally:
+        torch.set_default_dtype(old_dtype)
+
+
+def load_native_mace_checkpoint(
+    model_path: str | Path,
+    *,
+    device: str | torch.device,
+) -> ScaleShiftMACE:
+    """Load a trusted native MACE pickle checkpoint."""
+    model = torch.load(
+        str(model_path),
+        map_location=device,
+        weights_only=False,
+    )
+    if not isinstance(model, ScaleShiftMACE):
+        msg = (
+            "Loaded checkpoint is not a ScaleShiftMACE model: "
+            f"{model.__class__.__module__}.{model.__class__.__name__}"
+        )
+        raise TypeError(msg)
+    return model
+
+
+def _infer_gate(model: ScaleShiftMACE) -> str:
+    if not model.readouts:
+        return "None"
+    last_readout = model.readouts[-1]
+    non_linearity = getattr(last_readout, "non_linearity", None)
+    acts = getattr(non_linearity, "acts", None)
+    if acts is None or len(acts) != 1 or not hasattr(acts[0], "f"):
+        msg = "Unsupported MACE nonlinear readout structure"
+        raise ValueError(msg)
+    gate_fn = acts[0].f
+    for name, candidate in gate_dict.items():
+        if candidate is not None and candidate is gate_fn:
+            return name
+    msg = f"Unsupported MACE gate function: {gate_fn}"
+    raise ValueError(msg)
+
+
+def _infer_radial_mlp(model: ScaleShiftMACE) -> list[int]:
+    layers = [
+        layer
+        for layer in model.interactions[0].conv_tp_weights
+        if hasattr(layer, "weight")
+    ]
+    if len(layers) < 2:
+        msg = "Unsupported radial MLP structure in MACE checkpoint"
+        raise ValueError(msg)
+    return [int(layer.weight.shape[1]) for layer in layers[:-1]]
+
+
+def _infer_interactions(model: ScaleShiftMACE) -> tuple[str, str]:
+    names = [module.__class__.__name__ for module in model.interactions]
+    if not names:
+        msg = "Loaded MACE model has no interaction blocks"
+        raise ValueError(msg)
+    unsupported = [name for name in names if name not in interaction_classes]
+    if unsupported:
+        msg = f"Unsupported MACE interaction classes: {unsupported}"
+        raise ValueError(msg)
+    later = names[1:]
+    if later and len(set(later)) != 1:
+        msg = f"Mixed later interaction classes are unsupported: {names}"
+        raise ValueError(msg)
+    return names[0], later[0] if later else names[0]
+
+
+def _infer_correlations(model: ScaleShiftMACE) -> list[int]:
+    return [
+        int(product.symmetric_contractions.contractions[0].correlation)
+        for product in model.products
+    ]
+
+
+def inspect_native_mace_checkpoint(model: ScaleShiftMACE) -> MaceCheckpointConfig:
+    """Infer generic single-head feature-backbone construction metadata."""
+    atomic_numbers = [int(value) for value in model.atomic_numbers.tolist()]
+    if not atomic_numbers or any(
+        number < 1 or number >= len(chemical_symbols) for number in atomic_numbers
+    ):
+        msg = f"Unsupported atomic numbers in MACE checkpoint: {atomic_numbers}"
+        raise ValueError(msg)
+
+    raw_heads = getattr(model, "heads", None)
+    if raw_heads is not None and not isinstance(raw_heads, (list, tuple)):
+        msg = f"Unsupported MACE heads metadata: {raw_heads!r}"
+        raise ValueError(msg)
+    heads = None if raw_heads is None else list(raw_heads)
+    if heads is not None and len(heads) != 1:
+        msg = f"Multi-head MACE descriptors are unsupported: heads={heads}"
+        raise ValueError(msg)
+    if getattr(model, "embedding_specs", None) is not None:
+        msg = "Joint-embedding MACE descriptors are unsupported"
+        raise ValueError(msg)
+    for module in [model, *model.products]:
+        cueq_config = getattr(module, "cueq_config", None)
+        if cueq_config is not None and bool(getattr(cueq_config, "enabled", False)):
+            msg = "cuEquivariance MACE descriptors are unsupported"
+            raise ValueError(msg)
+
+    first_interaction, later_interaction = _infer_interactions(model)
+    transform = getattr(model.radial_embedding, "distance_transform", None)
+    transform_name = None if transform is None else transform.__class__.__name__
+    if transform_name not in _DISTANCE_TRANSFORMS:
+        msg = f"Unsupported MACE distance transform: {transform_name}"
+        raise ValueError(msg)
+    radial_name = model.radial_embedding.bessel_fn.__class__.__name__
+    if radial_name not in _RADIAL_BASES:
+        msg = f"Unsupported MACE radial basis: {radial_name}"
+        raise ValueError(msg)
+
+    last_readout = model.readouts[-1]
+    mlp_irreps = getattr(last_readout, "hidden_irreps", None)
+    if mlp_irreps is None:
+        msg = "Checkpoint does not expose nonlinear readout hidden irreps"
+        raise ValueError(msg)
+    scale = model.scale_shift.state_dict()["scale"].detach().cpu()
+    if scale.numel() != 1:
+        msg = f"Single-head MACE scale must be scalar, got shape {tuple(scale.shape)}"
+        raise ValueError(msg)
+
+    hidden_irreps = model.interactions[0].hidden_irreps
+    final_irreps = model.products[-1].linear.irreps_out
+    source_dtype = next(model.parameters()).dtype
+    edge_irreps = getattr(model, "edge_irreps", None)
+    return {
+        "type_map": [chemical_symbols[number] for number in atomic_numbers],
+        "r_max": float(model.r_max),
+        "num_radial_basis": len(
+            model.radial_embedding.bessel_fn.bessel_weights,
+        ),
+        "num_cutoff_basis": int(model.radial_embedding.cutoff_fn.p.item()),
+        "max_ell": max(ir.l for _, ir in model.spherical_harmonics.irreps_out),
+        "interaction_first": first_interaction,
+        "interaction": later_interaction,
+        "num_interactions": int(model.num_interactions),
+        "hidden_irreps": str(hidden_irreps),
+        "pair_repulsion": bool(getattr(model, "pair_repulsion", False)),
+        "apply_cutoff": bool(getattr(model, "apply_cutoff", True)),
+        "use_reduced_cg": bool(getattr(model, "use_reduced_cg", True)),
+        "use_so3": bool(getattr(model, "use_so3", False)),
+        "use_agnostic_product": bool(
+            getattr(model, "use_agnostic_product", False),
+        ),
+        "use_last_readout_only": bool(
+            getattr(model, "use_last_readout_only", False),
+        ),
+        "use_embedding_readout": bool(
+            getattr(model, "use_embedding_readout", False),
+        ),
+        "distance_transform": _DISTANCE_TRANSFORMS[transform_name],
+        "edge_irreps": None if edge_irreps is None else str(o3.Irreps(edge_irreps)),
+        "use_edge_irreps_first": bool(
+            getattr(model, "use_edge_irreps_first", False),
+        ),
+        "correlation": _infer_correlations(model),
+        "gate": _infer_gate(model),
+        "MLP_irreps": str(mlp_irreps),
+        "radial_type": _RADIAL_BASES[radial_name],
+        "radial_MLP": _infer_radial_mlp(model),
+        "std": float(scale.item()),
+        "avg_num_neighbors": float(model.interactions[0].avg_num_neighbors),
+        "keep_last_layer_irreps": str(final_irreps) == str(hidden_irreps),
+        "heads": heads,
+        "source_dtype": str(source_dtype).removeprefix("torch."),
+    }
+
+
+class MaceFeatureBackbone(torch.nn.Module):
+    """Only the MACE modules that contribute to product-layer features."""
+
+    def __init__(self, model: ScaleShiftMACE) -> None:
+        super().__init__()
+        self.node_embedding = model.node_embedding
+        self.spherical_harmonics = model.spherical_harmonics
+        self.radial_embedding = model.radial_embedding
+        self.interactions = model.interactions
+        self.products = model.products
+        self.register_buffer("atomic_numbers", model.atomic_numbers.detach().clone())
+
+
+def build_mace_feature_backbone(
+    config: MaceCheckpointConfig | dict[str, Any],
+) -> MaceFeatureBackbone:
+    """Rebuild a feature-only backbone from inspected checkpoint metadata."""
+    # Keep this import local: mace_network imports DeePMD's PT environment, whose
+    # entry-point registration imports MaceDescriptor and therefore this module.
+    from deepmd_gnn.mace_network import make_mace_network  # noqa: PLC0415
+
+    dtype_name = str(config.get("source_dtype", "float64"))
+    source_dtype = getattr(torch, dtype_name)
+    atomic_numbers = [chemical_symbols.index(name) for name in config["type_map"]]
+    with temporary_default_dtype(source_dtype):
+        model = make_mace_network(
+            r_max=config["r_max"],
+            num_radial_basis=config["num_radial_basis"],
+            num_cutoff_basis=config["num_cutoff_basis"],
+            max_ell=config["max_ell"],
+            interaction_first=config["interaction_first"],
+            interaction=config["interaction"],
+            num_interactions=config["num_interactions"],
+            num_elements=len(atomic_numbers),
+            hidden_irreps=config["hidden_irreps"],
+            atomic_numbers=atomic_numbers,
+            avg_num_neighbors=config["avg_num_neighbors"],
+            pair_repulsion=config["pair_repulsion"],
+            apply_cutoff=config["apply_cutoff"],
+            use_reduced_cg=config["use_reduced_cg"],
+            use_so3=config["use_so3"],
+            use_agnostic_product=config["use_agnostic_product"],
+            use_last_readout_only=config["use_last_readout_only"],
+            use_embedding_readout=config["use_embedding_readout"],
+            distance_transform=config["distance_transform"],
+            edge_irreps=config["edge_irreps"],
+            use_edge_irreps_first=config["use_edge_irreps_first"],
+            correlation=config["correlation"],
+            gate=config["gate"],
+            MLP_irreps=config["MLP_irreps"],
+            std=config["std"],
+            radial_MLP=config["radial_MLP"],
+            radial_type=config["radial_type"],
+            enable_cueq=False,
+            script_model=False,
+            keep_last_layer_irreps=config["keep_last_layer_irreps"],
+            heads=config["heads"],
+        )
+    return MaceFeatureBackbone(model)
+
+
+__all__ = [
+    "MaceCheckpointConfig",
+    "MaceFeatureBackbone",
+    "build_mace_feature_backbone",
+    "inspect_native_mace_checkpoint",
+    "load_native_mace_checkpoint",
+    "temporary_default_dtype",
+]

--- a/deepmd_gnn/mace_descriptor.py
+++ b/deepmd_gnn/mace_descriptor.py
@@ -150,6 +150,10 @@ class MaceDescriptor(BaseDescriptor, torch.nn.Module):
         for parameter in self.backbone.parameters():
             parameter.requires_grad_(self.trainable)
 
+    def has_default_chg_spin(self) -> bool:
+        """Declare absent charge/spin defaults for newer DeePMD model exports."""
+        return False
+
     def get_default_chg_spin(self) -> None:
         """Return no charge/spin defaults with a concrete TorchScript type."""
         return None  # noqa: RET501

--- a/deepmd_gnn/mace_descriptor.py
+++ b/deepmd_gnn/mace_descriptor.py
@@ -140,6 +140,17 @@ class MaceDescriptor(BaseDescriptor, torch.nn.Module):
         empty = torch.empty(0, dtype=env.GLOBAL_PT_FLOAT_PRECISION, device=env.DEVICE)
         self.register_buffer("_stat_mean", empty.clone(), persistent=False)
         self.register_buffer("_stat_stddev", empty.clone(), persistent=False)
+        # TorchScript cannot call ``next(self.backbone.parameters())``; keep a
+        # zero-size buffer whose dtype/device follow the feature backbone.
+        self.register_buffer(
+            "_backbone_probe",
+            torch.empty(
+                0,
+                dtype=next(self.backbone.parameters()).dtype,
+                device=env.DEVICE,
+            ),
+            persistent=False,
+        )
         for parameter in self.backbone.parameters():
             parameter.requires_grad_(self.trainable)
 
@@ -238,6 +249,7 @@ class MaceDescriptor(BaseDescriptor, torch.nn.Module):
             msg = "MACE descriptor only supports full-backbone sharing at level 0"
             raise NotImplementedError(msg)
         self.backbone = base_class.backbone
+        self._backbone_probe = base_class._backbone_probe
 
     def change_type_map(
         self,
@@ -259,7 +271,7 @@ class MaceDescriptor(BaseDescriptor, torch.nn.Module):
         nf, nloc, _ = nlist.shape
         nall = extended_atype.shape[1]
         positions = extended_coord.view(nf, nall, 3)
-        source_dtype = next(self.backbone.parameters()).dtype
+        source_dtype = self._backbone_probe.dtype
         positions_flat = positions.to(source_dtype).flatten(0, 1)
         atype = extended_atype.to(torch.int64)
         edge_index = torch.ops.deepmd_gnn.edge_index(
@@ -303,8 +315,10 @@ class MaceDescriptor(BaseDescriptor, torch.nn.Module):
             edge_index,
             self.backbone.atomic_numbers,
         )
-        for index, (interaction, product) in enumerate(
-            zip(self.backbone.interactions, self.backbone.products, strict=True),
+        first_layer = True
+        for interaction, product in zip(
+            self.backbone.interactions,
+            self.backbone.products,
         ):
             node_feats, sc = interaction(
                 node_attrs=node_attrs,
@@ -313,13 +327,14 @@ class MaceDescriptor(BaseDescriptor, torch.nn.Module):
                 edge_feats=edge_feats,
                 edge_index=edge_index,
                 cutoff=cutoff,
-                first_layer=index == 0,
+                first_layer=first_layer,
             )
             node_feats = product(
                 node_feats=node_feats,
                 sc=sc,
                 node_attrs=node_attrs,
             )
+            first_layer = False
         return node_feats.view(nf, nloc, -1)
 
     def forward(
@@ -355,7 +370,7 @@ class MaceDescriptor(BaseDescriptor, torch.nn.Module):
             index=self._scalar_indices.to(features.device),
         )
         return (
-            invariant.to(env.GLOBAL_PT_FLOAT_PRECISION),
+            invariant.to(self._stat_mean.dtype),
             None,
             None,
             None,

--- a/deepmd_gnn/mace_descriptor.py
+++ b/deepmd_gnn/mace_descriptor.py
@@ -132,25 +132,11 @@ class MaceDescriptor(BaseDescriptor, torch.nn.Module):
             msg = f"Final MACE product output has no 0e channels: {output_irreps}"
             raise ValueError(msg)
         self.output_irreps = str(output_irreps)
-        self.register_buffer(
-            "_scalar_indices",
-            torch.tensor(scalar_indices, dtype=torch.int64, device=env.DEVICE),
-            persistent=False,
-        )
-        empty = torch.empty(0, dtype=env.GLOBAL_PT_FLOAT_PRECISION, device=env.DEVICE)
-        self.register_buffer("_stat_mean", empty.clone(), persistent=False)
-        self.register_buffer("_stat_stddev", empty.clone(), persistent=False)
-        # TorchScript cannot call ``next(self.backbone.parameters())``; keep a
-        # zero-size buffer whose dtype/device follow the feature backbone.
-        self.register_buffer(
-            "_backbone_probe",
-            torch.empty(
-                0,
-                dtype=next(self.backbone.parameters()).dtype,
-                device=env.DEVICE,
-            ),
-            persistent=False,
-        )
+        # Keep these as plain attributes: jit.script promotes registered
+        # buffers into state_dict keys, which then fail to load training
+        # checkpoints that never saved them.
+        self.scalar_even_indices = scalar_indices
+        self.backbone_float64 = next(self.backbone.parameters()).dtype == torch.float64
         for parameter in self.backbone.parameters():
             parameter.requires_grad_(self.trainable)
 
@@ -176,7 +162,7 @@ class MaceDescriptor(BaseDescriptor, torch.nn.Module):
 
     def get_dim_out(self) -> int:
         """Return the number of final-layer ``0e`` channels."""
-        return int(self._scalar_indices.numel())
+        return len(self.scalar_even_indices)
 
     def get_dim_emb(self) -> int:
         """Return the invariant feature width."""
@@ -232,7 +218,8 @@ class MaceDescriptor(BaseDescriptor, torch.nn.Module):
 
     def get_stat_mean_and_stddev(self) -> tuple[torch.Tensor, torch.Tensor]:
         """Return empty compatibility statistics."""
-        return self._stat_mean, self._stat_stddev
+        empty = torch.empty(0, dtype=env.GLOBAL_PT_FLOAT_PRECISION, device=env.DEVICE)
+        return empty, empty.clone()
 
     def share_params(
         self,
@@ -249,7 +236,8 @@ class MaceDescriptor(BaseDescriptor, torch.nn.Module):
             msg = "MACE descriptor only supports full-backbone sharing at level 0"
             raise NotImplementedError(msg)
         self.backbone = base_class.backbone
-        self._backbone_probe = base_class._backbone_probe
+        self.scalar_even_indices = base_class.scalar_even_indices
+        self.backbone_float64 = base_class.backbone_float64
 
     def change_type_map(
         self,
@@ -271,7 +259,7 @@ class MaceDescriptor(BaseDescriptor, torch.nn.Module):
         nf, nloc, _ = nlist.shape
         nall = extended_atype.shape[1]
         positions = extended_coord.view(nf, nall, 3)
-        source_dtype = self._backbone_probe.dtype
+        source_dtype = torch.float64 if self.backbone_float64 else torch.float32
         positions_flat = positions.to(source_dtype).flatten(0, 1)
         atype = extended_atype.to(torch.int64)
         edge_index = torch.ops.deepmd_gnn.edge_index(
@@ -316,7 +304,7 @@ class MaceDescriptor(BaseDescriptor, torch.nn.Module):
             self.backbone.atomic_numbers,
         )
         first_layer = True
-        for interaction, product in zip(
+        for interaction, product in zip(  # noqa: B905
             self.backbone.interactions,
             self.backbone.products,
         ):
@@ -364,13 +352,18 @@ class MaceDescriptor(BaseDescriptor, torch.nn.Module):
             nlist,
             mapping,
         )
+        scalar_index = torch.tensor(
+            self.scalar_even_indices,
+            dtype=torch.int64,
+            device=features.device,
+        )
         invariant = torch.index_select(
             features,
             dim=-1,
-            index=self._scalar_indices.to(features.device),
+            index=scalar_index,
         )
         return (
-            invariant.to(self._stat_mean.dtype),
+            invariant.to(env.GLOBAL_PT_FLOAT_PRECISION),
             None,
             None,
             None,

--- a/deepmd_gnn/mace_descriptor.py
+++ b/deepmd_gnn/mace_descriptor.py
@@ -183,7 +183,8 @@ class MaceDescriptor(BaseDescriptor, torch.nn.Module):
                     enable_cueq=False,
                     script_model=False,
                     keep_last_layer_irreps=self.config.get(
-                        "keep_last_layer_irreps", False,
+                        "keep_last_layer_irreps",
+                        False,
                     ),
                 )
 
@@ -275,7 +276,9 @@ class MaceDescriptor(BaseDescriptor, torch.nn.Module):
         return {}
 
     def set_stat_mean_and_stddev(
-        self, mean: torch.Tensor, stddev: torch.Tensor,
+        self,
+        mean: torch.Tensor,
+        stddev: torch.Tensor,
     ) -> None:
         """Ignore external input statistics because MACE uses none."""
         del mean, stddev
@@ -285,7 +288,10 @@ class MaceDescriptor(BaseDescriptor, torch.nn.Module):
         return self._stat_mean, self._stat_stddev
 
     def share_params(
-        self, base_class: MaceDescriptor, shared_level: int, resume: bool = False,
+        self,
+        base_class: MaceDescriptor,
+        shared_level: int,
+        resume: bool = False,
     ) -> None:
         """Share a complete MACE backbone at level zero."""
         del resume
@@ -340,9 +346,7 @@ class MaceDescriptor(BaseDescriptor, torch.nn.Module):
                 device=mapping.device,
             ).unsqueeze(-1).expand(nf, nall).reshape(-1)
             image_shifts = positions_flat - positions_flat[mapping_flat]
-            shifts = (
-                image_shifts[edge_index[1]] - image_shifts[edge_index[0]]
-            )
+            shifts = image_shifts[edge_index[1]] - image_shifts[edge_index[0]]
             edge_index = mapping_flat[edge_index]
         elif self.num_interactions > 1 and nloc < nall:
             msg = "Multi-layer MACE descriptor requires mapping for extended atoms"
@@ -410,7 +414,10 @@ class MaceDescriptor(BaseDescriptor, torch.nn.Module):
             raise NotImplementedError(msg)
         del fparam, charge_spin
         features = self._final_product_features(
-            extended_coord, extended_atype, nlist, mapping,
+            extended_coord,
+            extended_atype,
+            nlist,
+            mapping,
         )
         invariant = torch.index_select(
             features,

--- a/deepmd_gnn/mace_descriptor.py
+++ b/deepmd_gnn/mace_descriptor.py
@@ -267,38 +267,32 @@ class MaceDescriptor(BaseDescriptor, torch.nn.Module):
             atype,
             torch.empty(0, dtype=torch.int64, device="cpu"),
         ).T
-        shifts = torch.zeros(
-            (edge_index.shape[1], 3),
-            dtype=source_dtype,
-            device=positions_flat.device,
-        )
-
-        if self.num_interactions > 1 and mapping is not None and nloc < nall:
-            mapping_flat = mapping.reshape(-1) + torch.arange(
-                0,
-                nf * nall,
-                nall,
-                dtype=mapping.dtype,
-                device=mapping.device,
-            ).unsqueeze(-1).expand(nf, nall).reshape(-1)
-            image_shifts = positions_flat - positions_flat[mapping_flat]
-            shifts = image_shifts[edge_index[1]] - image_shifts[edge_index[0]]
-            edge_index = mapping_flat[edge_index]
-        elif self.num_interactions > 1 and nloc < nall:
-            msg = "Multi-layer MACE descriptor requires mapping for extended atoms"
-            raise ValueError(msg)
-
         vectors = positions_flat[edge_index[1]] - positions_flat[edge_index[0]]
-        vectors = vectors + shifts
+        if nloc < nall:
+            if mapping is None:
+                msg = "MACE descriptor requires mapping for extended atoms"
+                raise ValueError(msg)
+            compact_mapping = (
+                mapping.to(torch.int64)
+                + torch.arange(
+                    nf,
+                    dtype=torch.int64,
+                    device=mapping.device,
+                ).unsqueeze(-1)
+                * nloc
+            )
+            edge_index = compact_mapping.reshape(-1)[edge_index]
+
         lengths = torch.linalg.norm(vectors, dim=-1, keepdim=True)
+        local_atype = atype[:, :nloc].reshape(-1)
         node_attrs = torch.zeros(
-            (nf * nall, self.ntypes),
+            (nf * nloc, self.ntypes),
             dtype=source_dtype,
             device=positions_flat.device,
         )
         node_attrs.scatter_(
             -1,
-            atype.reshape(-1, 1),
+            local_atype.unsqueeze(-1),
             1,
         )
         node_feats = self.backbone.node_embedding(node_attrs)
@@ -326,7 +320,7 @@ class MaceDescriptor(BaseDescriptor, torch.nn.Module):
                 sc=sc,
                 node_attrs=node_attrs,
             )
-        return node_feats.view(nf, nall, -1)[:, :nloc]
+        return node_feats.view(nf, nloc, -1)
 
     def forward(
         self,

--- a/deepmd_gnn/mace_descriptor.py
+++ b/deepmd_gnn/mace_descriptor.py
@@ -15,13 +15,11 @@ from deepmd.utils.version import check_version_compatibility
 from e3nn import o3
 
 import deepmd_gnn.op  # noqa: F401
-from deepmd_gnn.mace import PeriodicTable
-from deepmd_gnn.mace_network import make_mace_network
-from deepmd_gnn.mace_off import (
-    _infer_deepmd_config,
-    _load_mace_checkpoint,
-    _temporary_default_dtype,
-    _validate_load_result,
+from deepmd_gnn.mace_checkpoint import (
+    MaceFeatureBackbone,
+    build_mace_feature_backbone,
+    inspect_native_mace_checkpoint,
+    load_native_mace_checkpoint,
 )
 
 if TYPE_CHECKING:
@@ -55,38 +53,6 @@ def _product_output_irreps(model: torch.nn.Module) -> o3.Irreps:
         msg = "Final MACE product layer does not expose output irreps"
         raise ValueError(msg)
     return o3.Irreps(irreps_out)
-
-
-def _validate_descriptor_checkpoint(model: torch.nn.Module) -> None:
-    """Reject options that cannot be reconstructed during serialization."""
-    unsupported_flags = {
-        "use_agnostic_product": False,
-        "use_so3": False,
-        "use_last_readout_only": False,
-        "use_embedding_readout": False,
-        "use_edge_irreps_first": False,
-        "apply_cutoff": True,
-    }
-    for name, supported_value in unsupported_flags.items():
-        value = getattr(model, name, supported_value)
-        if value != supported_value:
-            msg = (
-                f"Unsupported MACE descriptor checkpoint option: {name}={value!r}; "
-                f"only {supported_value!r} is supported"
-            )
-            raise ValueError(msg)
-    if getattr(model, "use_reduced_cg", True) is False:
-        msg = "MACE descriptor checkpoints with use_reduced_cg=False are unsupported"
-        raise ValueError(msg)
-    if getattr(model, "edge_irreps", None) is not None:
-        msg = "MACE descriptor checkpoints with edge_irreps are unsupported"
-        raise ValueError(msg)
-
-    for module in [model, *getattr(model, "products", [])]:
-        cueq_config = getattr(module, "cueq_config", None)
-        if cueq_config is not None and bool(getattr(cueq_config, "enabled", False)):
-            msg = "cuEquivariance MACE descriptor checkpoints are unsupported"
-            raise ValueError(msg)
 
 
 @BaseDescriptor.register("mace")
@@ -133,15 +99,11 @@ class MaceDescriptor(BaseDescriptor, torch.nn.Module):
         self.model_path = None if model_path is None else str(model_path)
 
         if model_path is not None:
-            model = _load_mace_checkpoint(
+            model = load_native_mace_checkpoint(
                 Path(model_path),
                 device=str(env.DEVICE),
             )
-            _validate_descriptor_checkpoint(model)
-            inferred = _infer_deepmd_config(
-                model,
-                allow_pair_repulsion=True,
-            )
+            inferred = inspect_native_mace_checkpoint(model)
             checkpoint_type_map = inferred["type_map"]
             if self.type_map != checkpoint_type_map:
                 msg = (
@@ -150,46 +112,17 @@ class MaceDescriptor(BaseDescriptor, torch.nn.Module):
                 )
                 raise ValueError(msg)
             self.config = dict(inferred)
-            self.backbone = model
+            self.backbone = MaceFeatureBackbone(model)
         else:
             self.config = deepcopy(cast("dict[str, Any]", config))
-            checkpoint_type_map = self.config.pop("type_map", self.type_map)
+            checkpoint_type_map = self.config.get("type_map", self.type_map)
             if self.type_map != checkpoint_type_map:
                 msg = (
                     "Serialized MACE descriptor type_map mismatch: "
                     f"expected {checkpoint_type_map}, got {self.type_map}"
                 )
                 raise ValueError(msg)
-            source_dtype_name = self.config.pop("source_dtype", "float64")
-            source_dtype = getattr(torch, source_dtype_name)
-            atomic_numbers = [PeriodicTable[name] for name in self.type_map]
-            with _temporary_default_dtype(source_dtype):
-                self.backbone = make_mace_network(
-                    r_max=self.config["r_max"],
-                    num_radial_basis=self.config["num_radial_basis"],
-                    num_cutoff_basis=self.config["num_cutoff_basis"],
-                    max_ell=self.config["max_ell"],
-                    interaction=self.config["interaction"],
-                    num_interactions=self.config["num_interactions"],
-                    num_elements=self.ntypes,
-                    hidden_irreps=self.config["hidden_irreps"],
-                    atomic_numbers=atomic_numbers,
-                    avg_num_neighbors=self.config["avg_num_neighbors"],
-                    pair_repulsion=self.config["pair_repulsion"],
-                    distance_transform=self.config["distance_transform"],
-                    correlation=self.config["correlation"],
-                    gate=self.config["gate"],
-                    MLP_irreps=self.config["MLP_irreps"],
-                    std=self.config["std"],
-                    radial_MLP=self.config["radial_MLP"],
-                    radial_type=self.config["radial_type"],
-                    enable_cueq=False,
-                    script_model=False,
-                    keep_last_layer_irreps=self.config.get(
-                        "keep_last_layer_irreps",
-                        False,
-                    ),
-                )
+            self.backbone = build_mace_feature_backbone(self.config)
 
         self.rcut = float(self.config["r_max"])
         self.num_interactions = int(self.config["num_interactions"])
@@ -326,7 +259,7 @@ class MaceDescriptor(BaseDescriptor, torch.nn.Module):
         nf, nloc, _ = nlist.shape
         nall = extended_atype.shape[1]
         positions = extended_coord.view(nf, nall, 3)
-        source_dtype = self.backbone.atomic_energies_fn.atomic_energies.dtype
+        source_dtype = next(self.backbone.parameters()).dtype
         positions_flat = positions.to(source_dtype).flatten(0, 1)
         atype = extended_atype.to(torch.int64)
         edge_index = torch.ops.deepmd_gnn.edge_index(
@@ -437,10 +370,8 @@ class MaceDescriptor(BaseDescriptor, torch.nn.Module):
 
     def serialize(self) -> dict:
         """Serialize architecture and all trained backbone state."""
-        source_dtype = self.backbone.atomic_energies_fn.atomic_energies.dtype
         config = deepcopy(self.config)
         config["type_map"] = self.type_map
-        config["source_dtype"] = str(source_dtype).removeprefix("torch.")
         return {
             "@class": "Descriptor",
             "@version": 1,
@@ -470,8 +401,7 @@ class MaceDescriptor(BaseDescriptor, torch.nn.Module):
             for name, value in data.pop("@variables").items()
         }
         descriptor = cls(**data)
-        result = descriptor.backbone.load_state_dict(variables, strict=False)
-        _validate_load_result(result)
+        descriptor.backbone.load_state_dict(variables, strict=True)
         return descriptor
 
     @classmethod

--- a/deepmd_gnn/mace_descriptor.py
+++ b/deepmd_gnn/mace_descriptor.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 
 from copy import deepcopy
 from pathlib import Path
-from typing import TYPE_CHECKING, Any, cast
+from typing import TYPE_CHECKING, Any
 
 import torch
 from deepmd.pt.model.descriptor.base_descriptor import BaseDescriptor
@@ -20,6 +20,8 @@ from deepmd_gnn.mace_checkpoint import (
     build_mace_feature_backbone,
     inspect_native_mace_checkpoint,
     load_native_mace_checkpoint,
+    persistable_checkpoint_config,
+    validate_mace_state_dict_load,
 )
 
 if TYPE_CHECKING:
@@ -85,22 +87,15 @@ class MaceDescriptor(BaseDescriptor, torch.nn.Module):
         if ntypes is not None and ntypes != len(type_map):
             msg = f"ntypes={ntypes} does not match type_map length {len(type_map)}"
             raise ValueError(msg)
-        if (model_path is None) == (config is None):
-            msg = (
-                "Exactly one of model_path (initialization) or config "
-                "(deserialization) must be provided"
-            )
-            raise ValueError(msg)
 
         self.sel = int(sel)
         self.type_map = list(type_map)
         self.ntypes = len(self.type_map)
         self.trainable = bool(trainable)
-        self.model_path = None if model_path is None else str(model_path)
-
-        if model_path is not None:
+        source_path = None if model_path is None else Path(model_path)
+        if source_path is not None and source_path.is_file():
             model = load_native_mace_checkpoint(
-                Path(model_path),
+                source_path,
                 device=str(env.DEVICE),
             )
             inferred = inspect_native_mace_checkpoint(model)
@@ -111,10 +106,14 @@ class MaceDescriptor(BaseDescriptor, torch.nn.Module):
                     f"ordering: expected {checkpoint_type_map}, got {self.type_map}"
                 )
                 raise ValueError(msg)
-            self.config = dict(inferred)
+            self.config = persistable_checkpoint_config(inferred)
+            if config is not None:
+                config.clear()
+                config.update(self.config)
+            self.model_path = str(source_path)
             self.backbone = MaceFeatureBackbone(model)
-        else:
-            self.config = deepcopy(cast("dict[str, Any]", config))
+        elif config is not None:
+            self.config = persistable_checkpoint_config(config)
             checkpoint_type_map = self.config.get("type_map", self.type_map)
             if self.type_map != checkpoint_type_map:
                 msg = (
@@ -122,7 +121,17 @@ class MaceDescriptor(BaseDescriptor, torch.nn.Module):
                     f"expected {checkpoint_type_map}, got {self.type_map}"
                 )
                 raise ValueError(msg)
+            self.model_path = None
             self.backbone = build_mace_feature_backbone(self.config)
+        elif source_path is not None:
+            msg = f"MACE checkpoint not found: {source_path}"
+            raise FileNotFoundError(msg)
+        else:
+            msg = (
+                "Exactly one of model_path (initialization) or config "
+                "(deserialization) must be provided"
+            )
+            raise ValueError(msg)
 
         self.rcut = float(self.config["r_max"])
         self.num_interactions = int(self.config["num_interactions"])
@@ -139,6 +148,10 @@ class MaceDescriptor(BaseDescriptor, torch.nn.Module):
         self.backbone_float64 = next(self.backbone.parameters()).dtype == torch.float64
         for parameter in self.backbone.parameters():
             parameter.requires_grad_(self.trainable)
+
+    def get_default_chg_spin(self) -> None:
+        """Return no charge/spin defaults with a concrete TorchScript type."""
+        return None  # noqa: RET501
 
     def get_rcut(self) -> float:
         """Return the checkpoint cutoff radius."""
@@ -403,7 +416,9 @@ class MaceDescriptor(BaseDescriptor, torch.nn.Module):
             for name, value in data.pop("@variables").items()
         }
         descriptor = cls(**data)
-        descriptor.backbone.load_state_dict(variables, strict=True)
+        validate_mace_state_dict_load(
+            descriptor.backbone.load_state_dict(variables, strict=False),
+        )
         return descriptor
 
     @classmethod
@@ -413,13 +428,27 @@ class MaceDescriptor(BaseDescriptor, torch.nn.Module):
         type_map: list[str] | None,
         local_jdata: dict,
     ) -> tuple[dict, float | None]:
-        """Validate the required explicit neighbor-list capacity."""
-        del train_data, type_map
+        """Persist inferred architecture and validate neighbor-list capacity."""
+        del train_data
         local_jdata = local_jdata.copy()
         sel = local_jdata.get("sel")
         if not isinstance(sel, int) or isinstance(sel, bool) or sel <= 0:
             msg = "MACE descriptor requires an explicit positive integer sel"
             raise ValueError(msg)
+        model_path = local_jdata.get("model_path")
+        if model_path:
+            model = load_native_mace_checkpoint(Path(model_path), device="cpu")
+            inferred = persistable_checkpoint_config(
+                inspect_native_mace_checkpoint(model),
+            )
+            checkpoint_type_map = inferred["type_map"]
+            if type_map is not None and list(type_map) != checkpoint_type_map:
+                msg = (
+                    "Model-level type_map must exactly match checkpoint atomic-number "
+                    f"ordering: expected {checkpoint_type_map}, got {list(type_map)}"
+                )
+                raise ValueError(msg)
+            local_jdata["config"] = inferred
         return local_jdata, None
 
 

--- a/deepmd_gnn/mace_descriptor.py
+++ b/deepmd_gnn/mace_descriptor.py
@@ -138,7 +138,10 @@ class MaceDescriptor(BaseDescriptor, torch.nn.Module):
                 device=str(env.DEVICE),
             )
             _validate_descriptor_checkpoint(model)
-            inferred = _infer_deepmd_config(model)
+            inferred = _infer_deepmd_config(
+                model,
+                allow_pair_repulsion=True,
+            )
             checkpoint_type_map = inferred["type_map"]
             if self.type_map != checkpoint_type_map:
                 msg = (

--- a/deepmd_gnn/mace_descriptor.py
+++ b/deepmd_gnn/mace_descriptor.py
@@ -1,0 +1,484 @@
+# SPDX-License-Identifier: LGPL-3.0-or-later
+"""MACE backbone descriptor for DeePMD property fitting."""
+
+from __future__ import annotations
+
+from copy import deepcopy
+from pathlib import Path
+from typing import TYPE_CHECKING, Any, cast
+
+import torch
+from deepmd.pt.model.descriptor.base_descriptor import BaseDescriptor
+from deepmd.pt.utils import env
+from deepmd.pt.utils.utils import to_numpy_array, to_torch_tensor
+from deepmd.utils.version import check_version_compatibility
+from e3nn import o3
+
+import deepmd_gnn.op  # noqa: F401
+from deepmd_gnn.mace import PeriodicTable
+from deepmd_gnn.mace_network import make_mace_network
+from deepmd_gnn.mace_off import (
+    _infer_deepmd_config,
+    _load_mace_checkpoint,
+    _temporary_default_dtype,
+    _validate_load_result,
+)
+
+if TYPE_CHECKING:
+    from collections.abc import Callable
+
+    from deepmd.utils.data_system import DeepmdDataSystem
+    from deepmd.utils.path import DPPath
+
+
+def _scalar_even_indices(irreps: o3.Irreps) -> list[int]:
+    """Return flattened indices belonging to invariant, even scalar irreps."""
+    indices: list[int] = []
+    offset = 0
+    for multiplicity, irrep in irreps:
+        width = multiplicity * irrep.dim
+        if irrep.l == 0 and irrep.p == 1:
+            indices.extend(range(offset, offset + width))
+        offset += width
+    return indices
+
+
+def _product_output_irreps(model: torch.nn.Module) -> o3.Irreps:
+    """Read the actual output irreps of the final MACE product layer."""
+    products = getattr(model, "products", None)
+    if products is None or len(products) == 0:
+        msg = "Loaded MACE model has no product layers"
+        raise ValueError(msg)
+    linear = getattr(products[-1], "linear", None)
+    irreps_out = getattr(linear, "irreps_out", None)
+    if irreps_out is None:
+        msg = "Final MACE product layer does not expose output irreps"
+        raise ValueError(msg)
+    return o3.Irreps(irreps_out)
+
+
+def _validate_descriptor_checkpoint(model: torch.nn.Module) -> None:
+    """Reject options that cannot be reconstructed during serialization."""
+    unsupported_flags = {
+        "use_agnostic_product": False,
+        "use_so3": False,
+        "use_last_readout_only": False,
+        "use_embedding_readout": False,
+        "use_edge_irreps_first": False,
+        "apply_cutoff": True,
+    }
+    for name, supported_value in unsupported_flags.items():
+        value = getattr(model, name, supported_value)
+        if value != supported_value:
+            msg = (
+                f"Unsupported MACE descriptor checkpoint option: {name}={value!r}; "
+                f"only {supported_value!r} is supported"
+            )
+            raise ValueError(msg)
+    if getattr(model, "use_reduced_cg", True) is False:
+        msg = "MACE descriptor checkpoints with use_reduced_cg=False are unsupported"
+        raise ValueError(msg)
+    if getattr(model, "edge_irreps", None) is not None:
+        msg = "MACE descriptor checkpoints with edge_irreps are unsupported"
+        raise ValueError(msg)
+
+    for module in [model, *getattr(model, "products", [])]:
+        cueq_config = getattr(module, "cueq_config", None)
+        if cueq_config is not None and bool(getattr(cueq_config, "enabled", False)):
+            msg = "cuEquivariance MACE descriptor checkpoints are unsupported"
+            raise ValueError(msg)
+
+
+@BaseDescriptor.register("mace")
+class MaceDescriptor(BaseDescriptor, torch.nn.Module):
+    """Expose final MACE product-layer ``0e`` features as a DeePMD descriptor.
+
+    ``model_path`` is loaded with native Python pickle semantics and therefore
+    must point to a trusted local ``ScaleShiftMACE`` checkpoint.
+    """
+
+    def __init__(
+        self,
+        sel: int,
+        model_path: str | Path | None = None,
+        *,
+        type_map: list[str] | None = None,
+        ntypes: int | None = None,
+        trainable: bool = True,
+        config: dict[str, Any] | None = None,
+        **kwargs: Any,  # noqa: ANN401
+    ) -> None:
+        super().__init__()
+        del kwargs
+        if not isinstance(sel, int) or isinstance(sel, bool) or sel <= 0:
+            msg = f"sel must be an explicit positive integer, got {sel!r}"
+            raise ValueError(msg)
+        if type_map is None:
+            msg = "MACE descriptor requires the model-level type_map"
+            raise ValueError(msg)
+        if ntypes is not None and ntypes != len(type_map):
+            msg = f"ntypes={ntypes} does not match type_map length {len(type_map)}"
+            raise ValueError(msg)
+        if (model_path is None) == (config is None):
+            msg = (
+                "Exactly one of model_path (initialization) or config "
+                "(deserialization) must be provided"
+            )
+            raise ValueError(msg)
+
+        self.sel = int(sel)
+        self.type_map = list(type_map)
+        self.ntypes = len(self.type_map)
+        self.trainable = bool(trainable)
+        self.model_path = None if model_path is None else str(model_path)
+
+        if model_path is not None:
+            model = _load_mace_checkpoint(
+                Path(model_path),
+                device=str(env.DEVICE),
+            )
+            _validate_descriptor_checkpoint(model)
+            inferred = _infer_deepmd_config(model)
+            checkpoint_type_map = inferred["type_map"]
+            if self.type_map != checkpoint_type_map:
+                msg = (
+                    "Model-level type_map must exactly match checkpoint atomic-number "
+                    f"ordering: expected {checkpoint_type_map}, got {self.type_map}"
+                )
+                raise ValueError(msg)
+            self.config = dict(inferred)
+            self.backbone = model
+        else:
+            self.config = deepcopy(cast("dict[str, Any]", config))
+            checkpoint_type_map = self.config.pop("type_map", self.type_map)
+            if self.type_map != checkpoint_type_map:
+                msg = (
+                    "Serialized MACE descriptor type_map mismatch: "
+                    f"expected {checkpoint_type_map}, got {self.type_map}"
+                )
+                raise ValueError(msg)
+            source_dtype_name = self.config.pop("source_dtype", "float64")
+            source_dtype = getattr(torch, source_dtype_name)
+            atomic_numbers = [PeriodicTable[name] for name in self.type_map]
+            with _temporary_default_dtype(source_dtype):
+                self.backbone = make_mace_network(
+                    r_max=self.config["r_max"],
+                    num_radial_basis=self.config["num_radial_basis"],
+                    num_cutoff_basis=self.config["num_cutoff_basis"],
+                    max_ell=self.config["max_ell"],
+                    interaction=self.config["interaction"],
+                    num_interactions=self.config["num_interactions"],
+                    num_elements=self.ntypes,
+                    hidden_irreps=self.config["hidden_irreps"],
+                    atomic_numbers=atomic_numbers,
+                    avg_num_neighbors=self.config["avg_num_neighbors"],
+                    pair_repulsion=self.config["pair_repulsion"],
+                    distance_transform=self.config["distance_transform"],
+                    correlation=self.config["correlation"],
+                    gate=self.config["gate"],
+                    MLP_irreps=self.config["MLP_irreps"],
+                    std=self.config["std"],
+                    radial_MLP=self.config["radial_MLP"],
+                    radial_type=self.config["radial_type"],
+                    enable_cueq=False,
+                    script_model=False,
+                    keep_last_layer_irreps=self.config.get(
+                        "keep_last_layer_irreps", False,
+                    ),
+                )
+
+        self.rcut = float(self.config["r_max"])
+        self.num_interactions = int(self.config["num_interactions"])
+        output_irreps = _product_output_irreps(self.backbone)
+        scalar_indices = _scalar_even_indices(output_irreps)
+        if not scalar_indices:
+            msg = f"Final MACE product output has no 0e channels: {output_irreps}"
+            raise ValueError(msg)
+        self.output_irreps = str(output_irreps)
+        self.register_buffer(
+            "_scalar_indices",
+            torch.tensor(scalar_indices, dtype=torch.int64, device=env.DEVICE),
+            persistent=False,
+        )
+        empty = torch.empty(0, dtype=env.GLOBAL_PT_FLOAT_PRECISION, device=env.DEVICE)
+        self.register_buffer("_stat_mean", empty.clone(), persistent=False)
+        self.register_buffer("_stat_stddev", empty.clone(), persistent=False)
+        for parameter in self.backbone.parameters():
+            parameter.requires_grad_(self.trainable)
+
+    def get_rcut(self) -> float:
+        """Return the checkpoint cutoff radius."""
+        return self.rcut
+
+    def get_rcut_smth(self) -> float:
+        """Return the effective smooth cutoff radius."""
+        return self.rcut
+
+    def get_sel(self) -> list[int]:
+        """Return the mixed-type neighbor-list capacity."""
+        return [self.sel]
+
+    def get_ntypes(self) -> int:
+        """Return the number of checkpoint elements."""
+        return self.ntypes
+
+    def get_type_map(self) -> list[str]:
+        """Return checkpoint elements in atomic-number order."""
+        return self.type_map
+
+    def get_dim_out(self) -> int:
+        """Return the number of final-layer ``0e`` channels."""
+        return int(self._scalar_indices.numel())
+
+    def get_dim_emb(self) -> int:
+        """Return the invariant feature width."""
+        return self.get_dim_out()
+
+    def mixed_types(self) -> bool:
+        """Declare use of a mixed-type neighbor list."""
+        return True
+
+    def has_message_passing(self) -> bool:
+        """Return whether the backbone has multiple interaction layers."""
+        return self.num_interactions > 1
+
+    def has_message_passing_across_ranks(self) -> bool:
+        """Declare that cross-rank feature exchange is unsupported."""
+        return False
+
+    def supports_edge_parallel(self) -> bool:
+        """Declare MPI edge-parallel execution unsupported."""
+        return False
+
+    def dense_lower_supports_comm(self) -> bool:
+        """Declare that the dense lower does not accept communication data."""
+        return False
+
+    def need_sorted_nlist_for_lower(self) -> bool:
+        """Return whether lower neighbor lists need sorting."""
+        return False
+
+    def get_env_protection(self) -> float:
+        """Return the unused environment-matrix protection value."""
+        return 0.0
+
+    def compute_input_stats(
+        self,
+        merged: Callable[[], list[dict]] | list[dict],
+        path: DPPath | None = None,
+    ) -> None:
+        """Skip input statistics because MACE normalizes internally."""
+        del merged, path
+
+    def get_stats(self) -> dict:
+        """Return the empty input-statistics collection."""
+        return {}
+
+    def set_stat_mean_and_stddev(
+        self, mean: torch.Tensor, stddev: torch.Tensor,
+    ) -> None:
+        """Ignore external input statistics because MACE uses none."""
+        del mean, stddev
+
+    def get_stat_mean_and_stddev(self) -> tuple[torch.Tensor, torch.Tensor]:
+        """Return empty compatibility statistics."""
+        return self._stat_mean, self._stat_stddev
+
+    def share_params(
+        self, base_class: MaceDescriptor, shared_level: int, resume: bool = False,
+    ) -> None:
+        """Share a complete MACE backbone at level zero."""
+        del resume
+        if not isinstance(base_class, MaceDescriptor):
+            msg = "MACE descriptors can only share with MACE descriptors"
+            raise TypeError(msg)
+        if shared_level != 0:
+            msg = "MACE descriptor only supports full-backbone sharing at level 0"
+            raise NotImplementedError(msg)
+        self.backbone = base_class.backbone
+
+    def change_type_map(
+        self,
+        type_map: list[str],
+        model_with_new_type_stat: MaceDescriptor | None = None,
+    ) -> None:
+        """Reject type-map changes and subsets."""
+        del type_map, model_with_new_type_stat
+        msg = "MACE descriptor does not support changing or subsetting type_map"
+        raise NotImplementedError(msg)
+
+    def _final_product_features(
+        self,
+        extended_coord: torch.Tensor,
+        extended_atype: torch.Tensor,
+        nlist: torch.Tensor,
+        mapping: torch.Tensor | None,
+    ) -> torch.Tensor:
+        nf, nloc, _ = nlist.shape
+        nall = extended_atype.shape[1]
+        positions = extended_coord.view(nf, nall, 3)
+        source_dtype = self.backbone.atomic_energies_fn.atomic_energies.dtype
+        positions_flat = positions.to(source_dtype).flatten(0, 1)
+        atype = extended_atype.to(torch.int64)
+        edge_index = torch.ops.deepmd_gnn.edge_index(
+            nlist.to(torch.int64),
+            atype,
+            torch.empty(0, dtype=torch.int64, device="cpu"),
+        ).T
+        shifts = torch.zeros(
+            (edge_index.shape[1], 3),
+            dtype=source_dtype,
+            device=positions_flat.device,
+        )
+
+        if self.num_interactions > 1 and mapping is not None and nloc < nall:
+            mapping_flat = mapping.reshape(-1) + torch.arange(
+                0,
+                nf * nall,
+                nall,
+                dtype=mapping.dtype,
+                device=mapping.device,
+            ).unsqueeze(-1).expand(nf, nall).reshape(-1)
+            image_shifts = positions_flat - positions_flat[mapping_flat]
+            shifts = (
+                image_shifts[edge_index[1]] - image_shifts[edge_index[0]]
+            )
+            edge_index = mapping_flat[edge_index]
+        elif self.num_interactions > 1 and nloc < nall:
+            msg = "Multi-layer MACE descriptor requires mapping for extended atoms"
+            raise ValueError(msg)
+
+        vectors = positions_flat[edge_index[1]] - positions_flat[edge_index[0]]
+        vectors = vectors + shifts
+        lengths = torch.linalg.norm(vectors, dim=-1, keepdim=True)
+        node_attrs = torch.zeros(
+            (nf * nall, self.ntypes),
+            dtype=source_dtype,
+            device=positions_flat.device,
+        )
+        node_attrs.scatter_(
+            -1,
+            atype.reshape(-1, 1),
+            1,
+        )
+        node_feats = self.backbone.node_embedding(node_attrs)
+        edge_attrs = self.backbone.spherical_harmonics(vectors)
+        edge_feats, cutoff = self.backbone.radial_embedding(
+            lengths,
+            node_attrs,
+            edge_index,
+            self.backbone.atomic_numbers,
+        )
+        for index, (interaction, product) in enumerate(
+            zip(self.backbone.interactions, self.backbone.products, strict=True),
+        ):
+            node_feats, sc = interaction(
+                node_attrs=node_attrs,
+                node_feats=node_feats,
+                edge_attrs=edge_attrs,
+                edge_feats=edge_feats,
+                edge_index=edge_index,
+                cutoff=cutoff,
+                first_layer=index == 0,
+            )
+            node_feats = product(
+                node_feats=node_feats,
+                sc=sc,
+                node_attrs=node_attrs,
+            )
+        return node_feats.view(nf, nall, -1)[:, :nloc]
+
+    def forward(
+        self,
+        extended_coord: torch.Tensor,
+        extended_atype: torch.Tensor,
+        nlist: torch.Tensor,
+        mapping: torch.Tensor | None = None,
+        comm_dict: dict[str, torch.Tensor] | None = None,
+        fparam: torch.Tensor | None = None,
+        charge_spin: torch.Tensor | None = None,
+    ) -> tuple[
+        torch.Tensor,
+        torch.Tensor | None,
+        torch.Tensor | None,
+        torch.Tensor | None,
+        torch.Tensor | None,
+    ]:
+        """Compute local-atom invariant final-product features."""
+        if comm_dict is not None:
+            msg = "MPI communication is out of scope for the MACE descriptor"
+            raise NotImplementedError(msg)
+        del fparam, charge_spin
+        features = self._final_product_features(
+            extended_coord, extended_atype, nlist, mapping,
+        )
+        invariant = torch.index_select(
+            features,
+            dim=-1,
+            index=self._scalar_indices.to(features.device),
+        )
+        return (
+            invariant.to(env.GLOBAL_PT_FLOAT_PRECISION),
+            None,
+            None,
+            None,
+            None,
+        )
+
+    def serialize(self) -> dict:
+        """Serialize architecture and all trained backbone state."""
+        source_dtype = self.backbone.atomic_energies_fn.atomic_energies.dtype
+        config = deepcopy(self.config)
+        config["type_map"] = self.type_map
+        config["source_dtype"] = str(source_dtype).removeprefix("torch.")
+        return {
+            "@class": "Descriptor",
+            "@version": 1,
+            "type": "mace",
+            "sel": self.sel,
+            "model_path": None,
+            "type_map": self.type_map,
+            "ntypes": self.ntypes,
+            "trainable": self.trainable,
+            "config": config,
+            "@variables": {
+                name: to_numpy_array(value)
+                for name, value in self.backbone.state_dict().items()
+            },
+        }
+
+    @classmethod
+    def deserialize(cls, data: dict) -> MaceDescriptor:
+        """Restore a self-contained serialized MACE descriptor."""
+        data = data.copy()
+        if data.pop("@class") != "Descriptor" or data.pop("type") != "mace":
+            msg = "data is not a serialized MaceDescriptor"
+            raise ValueError(msg)
+        check_version_compatibility(data.pop("@version"), 1, 1)
+        variables = {
+            name: to_torch_tensor(value)
+            for name, value in data.pop("@variables").items()
+        }
+        descriptor = cls(**data)
+        result = descriptor.backbone.load_state_dict(variables, strict=False)
+        _validate_load_result(result)
+        return descriptor
+
+    @classmethod
+    def update_sel(
+        cls,
+        train_data: DeepmdDataSystem,
+        type_map: list[str] | None,
+        local_jdata: dict,
+    ) -> tuple[dict, float | None]:
+        """Validate the required explicit neighbor-list capacity."""
+        del train_data, type_map
+        local_jdata = local_jdata.copy()
+        sel = local_jdata.get("sel")
+        if not isinstance(sel, int) or isinstance(sel, bool) or sel <= 0:
+            msg = "MACE descriptor requires an explicit positive integer sel"
+            raise ValueError(msg)
+        return local_jdata, None
+
+
+__all__ = ["MaceDescriptor"]

--- a/deepmd_gnn/mace_descriptor.py
+++ b/deepmd_gnn/mace_descriptor.py
@@ -92,6 +92,7 @@ class MaceDescriptor(BaseDescriptor, torch.nn.Module):
         self.type_map = list(type_map)
         self.ntypes = len(self.type_map)
         self.trainable = bool(trainable)
+        self.model_path: str | None = None
         source_path = None if model_path is None else Path(model_path)
         if source_path is not None and source_path.is_file():
             model = load_native_mace_checkpoint(
@@ -436,7 +437,11 @@ class MaceDescriptor(BaseDescriptor, torch.nn.Module):
             msg = "MACE descriptor requires an explicit positive integer sel"
             raise ValueError(msg)
         model_path = local_jdata.get("model_path")
-        if model_path:
+        # Initialization from a trained checkpoint repeats neighbor selection
+        # with its saved definition, after the native pickle may have moved.
+        if model_path and (
+            local_jdata.get("config") is None or Path(model_path).is_file()
+        ):
             model = load_native_mace_checkpoint(Path(model_path), device="cpu")
             inferred = persistable_checkpoint_config(
                 inspect_native_mace_checkpoint(model),

--- a/deepmd_gnn/mace_network.py
+++ b/deepmd_gnn/mace_network.py
@@ -115,6 +115,7 @@ def make_mace_network(
     radial_type: str,
     enable_cueq: bool,
     script_model: bool,
+    keep_last_layer_irreps: bool = False,
 ) -> torch.nn.Module:
     """Create a configured MACE subnetwork for DeePMD-GNN."""
     optimization_defaults = None
@@ -145,6 +146,11 @@ def make_mace_network(
             radial_MLP=radial_MLP,
             radial_type=radial_type,
             cueq_config=make_cueq_config(enable_cueq),
+            **(
+                {"keep_last_layer_irreps": True}
+                if keep_last_layer_irreps
+                else {}
+            ),
         ).to(env.DEVICE)
     finally:
         if optimization_defaults is not None:

--- a/deepmd_gnn/mace_network.py
+++ b/deepmd_gnn/mace_network.py
@@ -146,11 +146,7 @@ def make_mace_network(
             radial_MLP=radial_MLP,
             radial_type=radial_type,
             cueq_config=make_cueq_config(enable_cueq),
-            **(
-                {"keep_last_layer_irreps": True}
-                if keep_last_layer_irreps
-                else {}
-            ),
+            **({"keep_last_layer_irreps": True} if keep_last_layer_irreps else {}),
         ).to(env.DEVICE)
     finally:
         if optimization_defaults is not None:

--- a/deepmd_gnn/mace_network.py
+++ b/deepmd_gnn/mace_network.py
@@ -10,6 +10,7 @@ back to e3nn weights when DeePMD freezes an exportable model.
 from __future__ import annotations
 
 import importlib
+import inspect
 import warnings
 from collections.abc import MutableMapping
 from typing import Any
@@ -20,6 +21,7 @@ from deepmd.pt.utils import env
 from e3nn import o3
 from e3nn.util.jit import script
 from mace.modules import (
+    MACE,
     ScaleShiftMACE,
     gate_dict,
     interaction_classes,
@@ -100,6 +102,7 @@ def make_mace_network(
     num_cutoff_basis: int,
     max_ell: int,
     interaction: str,
+    interaction_first: str = "RealAgnosticInteractionBlock",
     num_interactions: int,
     num_elements: int,
     hidden_irreps: str,
@@ -107,7 +110,7 @@ def make_mace_network(
     avg_num_neighbors: float,
     pair_repulsion: bool,
     distance_transform: str,
-    correlation: int,
+    correlation: int | list[int],
     gate: str,
     MLP_irreps: str,
     std: float,
@@ -116,6 +119,15 @@ def make_mace_network(
     enable_cueq: bool,
     script_model: bool,
     keep_last_layer_irreps: bool = False,
+    heads: list[str] | None = None,
+    apply_cutoff: bool = True,
+    use_reduced_cg: bool = True,
+    use_so3: bool = False,
+    use_agnostic_product: bool = False,
+    use_last_readout_only: bool = False,
+    use_embedding_readout: bool = False,
+    edge_irreps: str | None = None,
+    use_edge_irreps_first: bool = False,
 ) -> torch.nn.Module:
     """Create a configured MACE subnetwork for DeePMD-GNN."""
     optimization_defaults = None
@@ -123,30 +135,62 @@ def make_mace_network(
         optimization_defaults = e3nn.get_optimization_defaults()
         e3nn.set_optimization_defaults(jit_script_fx=False)
     try:
+        atomic_energies = (
+            torch.zeros(num_elements)
+            if heads is None
+            else torch.zeros((len(heads), num_elements))
+        )
+        optional_values = {
+            "apply_cutoff": (apply_cutoff, True),
+            "use_reduced_cg": (use_reduced_cg, True),
+            "use_so3": (use_so3, False),
+            "use_agnostic_product": (use_agnostic_product, False),
+            "use_last_readout_only": (use_last_readout_only, False),
+            "use_embedding_readout": (use_embedding_readout, False),
+            "edge_irreps": (
+                None if edge_irreps is None else o3.Irreps(edge_irreps),
+                None,
+            ),
+            "use_edge_irreps_first": (use_edge_irreps_first, False),
+            "heads": (heads, None),
+            "keep_last_layer_irreps": (keep_last_layer_irreps, False),
+        }
+        constructor_parameters = inspect.signature(MACE.__init__).parameters
+        optional_kwargs: dict[str, Any] = {}
+        for name, (value, default) in optional_values.items():
+            if name in constructor_parameters:
+                optional_kwargs[name] = value
+            elif value != default and not (name == "heads" and value == ["Default"]):
+                msg = (
+                    f"Installed MACE does not support checkpoint option "
+                    f"{name}={value!r}"
+                )
+                raise ValueError(msg)
+
         model = ScaleShiftMACE(
             r_max=r_max,
             num_bessel=num_radial_basis,
             num_polynomial_cutoff=num_cutoff_basis,
             max_ell=max_ell,
             interaction_cls=interaction_classes[interaction],
+            interaction_cls_first=interaction_classes[interaction_first],
             num_interactions=num_interactions,
             num_elements=num_elements,
             hidden_irreps=o3.Irreps(hidden_irreps),
-            atomic_energies=torch.zeros(num_elements),  # pylint: disable=no-explicit-device,no-explicit-dtype
+            atomic_energies=atomic_energies,  # pylint: disable=no-explicit-device,no-explicit-dtype
             avg_num_neighbors=avg_num_neighbors,
             atomic_numbers=atomic_numbers,
             pair_repulsion=pair_repulsion,
             distance_transform=distance_transform,
             correlation=correlation,
             gate=gate_dict[gate],
-            interaction_cls_first=interaction_classes["RealAgnosticInteractionBlock"],
             MLP_irreps=o3.Irreps(MLP_irreps),
             atomic_inter_scale=std,
             atomic_inter_shift=0.0,
             radial_MLP=radial_MLP,
             radial_type=radial_type,
             cueq_config=make_cueq_config(enable_cueq),
-            **({"keep_last_layer_irreps": True} if keep_last_layer_irreps else {}),
+            **optional_kwargs,
         ).to(env.DEVICE)
     finally:
         if optimization_defaults is not None:

--- a/deepmd_gnn/mace_off.py
+++ b/deepmd_gnn/mace_off.py
@@ -233,9 +233,7 @@ def _validate_checkpoint_scope(mace_model: ScaleShiftMACE) -> None:
     _validate_atomic_numbers(atomic_numbers)
 
     heads = getattr(mace_model, "heads", None)
-    if heads is not None and (
-        not isinstance(heads, (list, tuple)) or len(heads) != 1
-    ):
+    if heads is not None and (not isinstance(heads, (list, tuple)) or len(heads) != 1):
         msg = f"Multi-head checkpoints are unsupported: heads={heads}"
         raise ValueError(msg)
 

--- a/deepmd_gnn/mace_off.py
+++ b/deepmd_gnn/mace_off.py
@@ -233,7 +233,9 @@ def _validate_checkpoint_scope(mace_model: ScaleShiftMACE) -> None:
     _validate_atomic_numbers(atomic_numbers)
 
     heads = getattr(mace_model, "heads", None)
-    if heads not in (None, ["Default"]):
+    if heads is not None and (
+        not isinstance(heads, (list, tuple)) or len(heads) != 1
+    ):
         msg = f"Multi-head checkpoints are unsupported: heads={heads}"
         raise ValueError(msg)
 

--- a/deepmd_gnn/mace_off.py
+++ b/deepmd_gnn/mace_off.py
@@ -89,12 +89,13 @@ def _load_e3nn_script() -> Callable[[torch.nn.Module], torch.nn.Module]:
 
 @contextmanager
 def _temporary_default_dtype(dtype: torch.dtype) -> Iterator[None]:
-    old_dtype = torch.get_default_dtype()
-    torch.set_default_dtype(dtype)
-    try:
+    """Compatibility alias for the generic checkpoint construction helper."""
+    from deepmd_gnn.mace_checkpoint import (  # noqa: PLC0415
+        temporary_default_dtype,
+    )
+
+    with temporary_default_dtype(dtype):
         yield
-    finally:
-        torch.set_default_dtype(old_dtype)
 
 
 def _validate_atomic_numbers(atomic_numbers: list[int]) -> None:
@@ -228,16 +229,12 @@ def _infer_keep_last_layer_irreps(mace_model: ScaleShiftMACE) -> bool:
     return str(final_irreps) == str(hidden_irreps)
 
 
-def _validate_checkpoint_scope(
-    mace_model: ScaleShiftMACE,
-    *,
-    allow_pair_repulsion: bool = False,
-) -> None:
+def _validate_checkpoint_scope(mace_model: ScaleShiftMACE) -> None:
     atomic_numbers = mace_model.atomic_numbers.tolist()
     _validate_atomic_numbers(atomic_numbers)
 
     heads = getattr(mace_model, "heads", None)
-    if heads is not None and (not isinstance(heads, (list, tuple)) or len(heads) != 1):
+    if heads not in (None, ["Default"]):
         msg = f"Multi-head checkpoints are unsupported: heads={heads}"
         raise ValueError(msg)
 
@@ -248,24 +245,14 @@ def _validate_checkpoint_scope(
         msg = "Joint-embedding checkpoints are unsupported by the conservative loader"
         raise ValueError(msg)
 
-    if (
-        bool(getattr(mace_model, "pair_repulsion", False))
-        and not allow_pair_repulsion
-    ):
+    if bool(getattr(mace_model, "pair_repulsion", False)):
         msg = "Pair-repulsion checkpoints are unsupported by the conservative loader"
         raise ValueError(msg)
 
 
-def _infer_deepmd_config(
-    mace_model: ScaleShiftMACE,
-    *,
-    allow_pair_repulsion: bool = False,
-) -> _InferredMaceConfig:
+def _infer_deepmd_config(mace_model: ScaleShiftMACE) -> _InferredMaceConfig:
     elements = _load_deepmd_mace_symbols()[0]
-    _validate_checkpoint_scope(
-        mace_model,
-        allow_pair_repulsion=allow_pair_repulsion,
-    )
+    _validate_checkpoint_scope(mace_model)
     atomic_numbers = mace_model.atomic_numbers.tolist()
 
     return {
@@ -277,7 +264,7 @@ def _infer_deepmd_config(
         "interaction": _infer_interaction_name(mace_model),
         "num_interactions": int(mace_model.num_interactions),
         "hidden_irreps": _infer_hidden_irreps(mace_model),
-        "pair_repulsion": bool(getattr(mace_model, "pair_repulsion", False)),
+        "pair_repulsion": False,
         "distance_transform": _infer_distance_transform(mace_model),
         "correlation": _infer_correlation(mace_model),
         "gate": _infer_gate_name(mace_model),
@@ -301,15 +288,11 @@ def _load_mace_checkpoint(model_path: Path, device: str) -> ScaleShiftMACE:
     callers should only use trusted checkpoint files, whether downloaded from the
     official download helper or supplied via a trusted local path.
     """
-    scale_shift_mace_cls = _load_mace_modules()[0]
-    model = torch.load(str(model_path), map_location=device, weights_only=False)
-    if not isinstance(model, scale_shift_mace_cls):
-        msg = (
-            "Loaded checkpoint is not a ScaleShiftMACE model: "
-            f"{model.__class__.__module__}.{model.__class__.__name__}"
-        )
-        raise TypeError(msg)
-    return model
+    from deepmd_gnn.mace_checkpoint import (  # noqa: PLC0415
+        load_native_mace_checkpoint,
+    )
+
+    return load_native_mace_checkpoint(model_path, device=device)
 
 
 def _validate_load_result(load_result: object) -> None:

--- a/deepmd_gnn/mace_off.py
+++ b/deepmd_gnn/mace_off.py
@@ -27,8 +27,6 @@ if TYPE_CHECKING:
 
     from deepmd_gnn.mace import MaceModel
 
-_ALLOWED_MISSING_STATE_DICT_SUFFIXES = ("_zeroed",)
-
 _SUPPORTED_DISTANCE_TRANSFORMS = {
     None: "None",
     "AgnesiTransform": "Agnesi",
@@ -296,20 +294,11 @@ def _load_mace_checkpoint(model_path: Path, device: str) -> ScaleShiftMACE:
 
 
 def _validate_load_result(load_result: object) -> None:
-    missing_keys = list(getattr(load_result, "missing_keys", []))
-    unexpected_keys = list(getattr(load_result, "unexpected_keys", []))
+    from deepmd_gnn.mace_checkpoint import (  # noqa: PLC0415
+        validate_mace_state_dict_load,
+    )
 
-    disallowed_missing_keys = [
-        key
-        for key in missing_keys
-        if not key.endswith(_ALLOWED_MISSING_STATE_DICT_SUFFIXES)
-    ]
-    if disallowed_missing_keys or unexpected_keys:
-        msg = (
-            "Failed to load MACE checkpoint into DeePMD-GNN wrapper. "
-            f"missing={disallowed_missing_keys}, unexpected={unexpected_keys}"
-        )
-        raise RuntimeError(msg)
+    validate_mace_state_dict_load(load_result)
 
 
 def load_mace_off_model(

--- a/deepmd_gnn/mace_off.py
+++ b/deepmd_gnn/mace_off.py
@@ -228,7 +228,11 @@ def _infer_keep_last_layer_irreps(mace_model: ScaleShiftMACE) -> bool:
     return str(final_irreps) == str(hidden_irreps)
 
 
-def _validate_checkpoint_scope(mace_model: ScaleShiftMACE) -> None:
+def _validate_checkpoint_scope(
+    mace_model: ScaleShiftMACE,
+    *,
+    allow_pair_repulsion: bool = False,
+) -> None:
     atomic_numbers = mace_model.atomic_numbers.tolist()
     _validate_atomic_numbers(atomic_numbers)
 
@@ -246,14 +250,24 @@ def _validate_checkpoint_scope(mace_model: ScaleShiftMACE) -> None:
         msg = "Joint-embedding checkpoints are unsupported by the conservative loader"
         raise ValueError(msg)
 
-    if bool(getattr(mace_model, "pair_repulsion", False)):
+    if (
+        bool(getattr(mace_model, "pair_repulsion", False))
+        and not allow_pair_repulsion
+    ):
         msg = "Pair-repulsion checkpoints are unsupported by the conservative loader"
         raise ValueError(msg)
 
 
-def _infer_deepmd_config(mace_model: ScaleShiftMACE) -> _InferredMaceConfig:
+def _infer_deepmd_config(
+    mace_model: ScaleShiftMACE,
+    *,
+    allow_pair_repulsion: bool = False,
+) -> _InferredMaceConfig:
     elements = _load_deepmd_mace_symbols()[0]
-    _validate_checkpoint_scope(mace_model)
+    _validate_checkpoint_scope(
+        mace_model,
+        allow_pair_repulsion=allow_pair_repulsion,
+    )
     atomic_numbers = mace_model.atomic_numbers.tolist()
 
     return {
@@ -265,7 +279,7 @@ def _infer_deepmd_config(mace_model: ScaleShiftMACE) -> _InferredMaceConfig:
         "interaction": _infer_interaction_name(mace_model),
         "num_interactions": int(mace_model.num_interactions),
         "hidden_irreps": _infer_hidden_irreps(mace_model),
-        "pair_repulsion": False,
+        "pair_repulsion": bool(getattr(mace_model, "pair_repulsion", False)),
         "distance_transform": _infer_distance_transform(mace_model),
         "correlation": _infer_correlation(mace_model),
         "gate": _infer_gate_name(mace_model),

--- a/deepmd_gnn/mace_off.py
+++ b/deepmd_gnn/mace_off.py
@@ -248,10 +248,7 @@ def _validate_checkpoint_scope(
         msg = "Joint-embedding checkpoints are unsupported by the conservative loader"
         raise ValueError(msg)
 
-    if (
-        bool(getattr(mace_model, "pair_repulsion", False))
-        and not allow_pair_repulsion
-    ):
+    if bool(getattr(mace_model, "pair_repulsion", False)) and not allow_pair_repulsion:
         msg = "Pair-repulsion checkpoints are unsupported by the conservative loader"
         raise ValueError(msg)
 

--- a/deepmd_gnn/mace_off.py
+++ b/deepmd_gnn/mace_off.py
@@ -58,6 +58,7 @@ class _InferredMaceConfig(TypedDict):
     radial_MLP: list[int]
     std: float
     avg_num_neighbors: float
+    keep_last_layer_irreps: bool
 
 
 @lru_cache(maxsize=1)
@@ -220,6 +221,13 @@ def _infer_avg_num_neighbors(mace_model: ScaleShiftMACE) -> float:
     return float(mace_model.interactions[0].avg_num_neighbors)
 
 
+def _infer_keep_last_layer_irreps(mace_model: ScaleShiftMACE) -> bool:
+    """Infer the constructor flag from the final product's actual output."""
+    hidden_irreps = mace_model.interactions[0].hidden_irreps
+    final_irreps = mace_model.products[-1].linear.irreps_out
+    return str(final_irreps) == str(hidden_irreps)
+
+
 def _validate_checkpoint_scope(mace_model: ScaleShiftMACE) -> None:
     atomic_numbers = mace_model.atomic_numbers.tolist()
     _validate_atomic_numbers(atomic_numbers)
@@ -264,6 +272,7 @@ def _infer_deepmd_config(mace_model: ScaleShiftMACE) -> _InferredMaceConfig:
         "radial_MLP": _infer_radial_mlp(mace_model),
         "std": _infer_scale(mace_model),
         "avg_num_neighbors": _infer_avg_num_neighbors(mace_model),
+        "keep_last_layer_irreps": _infer_keep_last_layer_irreps(mace_model),
     }
 
 

--- a/deepmd_gnn/pt.py
+++ b/deepmd_gnn/pt.py
@@ -24,6 +24,7 @@ def _register() -> None:
     )
 
     from deepmd_gnn.mace import MaceModel  # noqa: PLC0415
+    from deepmd_gnn.mace_descriptor import MaceDescriptor  # noqa: F401, PLC0415
     from deepmd_gnn.nequip import NequipModel  # noqa: PLC0415
 
     PyTorchBaseModel.register("mace")(MaceModel)

--- a/deepmd_gnn/pt.py
+++ b/deepmd_gnn/pt.py
@@ -23,8 +23,8 @@ def _register() -> None:
         BaseModel as PyTorchBaseModel,
     )
 
+    import deepmd_gnn.mace_descriptor  # noqa: F401, PLC0415
     from deepmd_gnn.mace import MaceModel  # noqa: PLC0415
-    from deepmd_gnn.mace_descriptor import MaceDescriptor  # noqa: F401, PLC0415
     from deepmd_gnn.nequip import NequipModel  # noqa: PLC0415
 
     PyTorchBaseModel.register("mace")(MaceModel)

--- a/examples/property/mace/input.json
+++ b/examples/property/mace/input.json
@@ -1,0 +1,44 @@
+{
+  "model": {
+    "type": "standard",
+    "type_map": [
+      "H",
+      "O"
+    ],
+    "descriptor": {
+      "type": "mace",
+      "model_path": "./trusted_scale_shift_mace.model",
+      "sel": 64,
+      "trainable": true
+    },
+    "fitting_net": {
+      "type": "property",
+      "property_name": "band_gap",
+      "task_dim": 1,
+      "neuron": [
+        128,
+        128
+      ]
+    }
+  },
+  "learning_rate": {
+    "type": "exp",
+    "decay_steps": 5000,
+    "start_lr": 0.0001,
+    "stop_lr": 1e-08
+  },
+  "loss": {
+    "type": "property"
+  },
+  "training": {
+    "training_data": {
+      "systems": [
+        "../../data/property"
+      ],
+      "batch_size": 1
+    },
+    "numb_steps": 100000,
+    "disp_freq": 100,
+    "save_freq": 1000
+  }
+}

--- a/examples/property/mace/input.json
+++ b/examples/property/mace/input.json
@@ -7,7 +7,7 @@
     ],
     "descriptor": {
       "type": "mace",
-      "model_path": "./trusted_scale_shift_mace.model",
+      "model_path": "./trusted_single_head_mace_mp_or_mpa.model",
       "sel": 64,
       "trainable": true
     },

--- a/tests/test_mace_descriptor.py
+++ b/tests/test_mace_descriptor.py
@@ -15,6 +15,7 @@ import pytest
 import torch
 from deepmd.pt.model.descriptor.base_descriptor import BaseDescriptor
 from deepmd.pt.model.model import get_model
+from deepmd.pt.utils import env
 from deepmd.pt.utils.nlist import extend_input_and_build_neighbor_list
 from e3nn import o3
 from mace.modules import MACE
@@ -106,7 +107,10 @@ def _inputs(
             [[[0.0, 0.0, 0.0], [0.9, 0.1, 0.0], [-0.2, 1.0, 0.3]]],
             dtype=torch.float64,
         )
-    atype = torch.tensor([[1, 0, 0]], dtype=torch.int64)
+    coord = coord.to(env.DEVICE)
+    atype = torch.tensor([[1, 0, 0]], dtype=torch.int64, device=env.DEVICE)
+    if box is not None:
+        box = box.to(env.DEVICE)
     coord_ext, atype_ext, mapping, nlist = extend_input_and_build_neighbor_list(
         coord.reshape(1, -1),
         atype,
@@ -284,8 +288,9 @@ def test_property_model_composition_and_optimizer_step(
     coord = torch.tensor(
         [[[0.0, 0.0, 0.0], [0.9, 0.1, 0.0], [-0.2, 1.0, 0.3]]],
         dtype=torch.float64,
+        device=env.DEVICE,
     ).reshape(1, -1)
-    atype = torch.tensor([[1, 0, 0]], dtype=torch.int64)
+    atype = torch.tensor([[1, 0, 0]], dtype=torch.int64, device=env.DEVICE)
     optimizer = torch.optim.SGD(model.parameters(), lr=1e-3)
     loss = model(coord, atype)["band_gap"].square().sum()
     optimizer.zero_grad()
@@ -430,7 +435,7 @@ def test_checkpoint_feature_parity_and_serialization_roundtrip(
         mace_checkpoint, map_location="cpu", weights_only=False,
     ).state_dict()
     for name, value in descriptor.backbone.state_dict().items():
-        torch.testing.assert_close(value, original_state[name])
+        torch.testing.assert_close(value.cpu(), original_state[name].cpu())
 
     expected = _descriptor_output(descriptor)
     serialized = descriptor.serialize()
@@ -439,7 +444,10 @@ def test_checkpoint_feature_parity_and_serialization_roundtrip(
     actual = _descriptor_output(restored)
     torch.testing.assert_close(actual, expected)
     for name, value in descriptor.backbone.state_dict().items():
-        torch.testing.assert_close(value, restored.backbone.state_dict()[name])
+        torch.testing.assert_close(
+            value.cpu(),
+            restored.backbone.state_dict()[name].cpu(),
+        )
 
 
 @pytest.mark.slow
@@ -454,8 +462,9 @@ def test_off23_small_checkpoint_features_and_gradients(tmp_path: Path) -> None:
     coord = torch.tensor(
         [[[0.0, 0.0, 0.0], [0.9572, 0.0, 0.0], [-0.2390, 0.9266, 0.0]]],
         dtype=torch.float64,
+        device=env.DEVICE,
     )
-    atype = torch.tensor([[3, 0, 0]], dtype=torch.int64)
+    atype = torch.tensor([[3, 0, 0]], dtype=torch.int64, device=env.DEVICE)
     coord_ext, atype_ext, mapping, nlist = extend_input_and_build_neighbor_list(
         coord.reshape(1, -1),
         atype,

--- a/tests/test_mace_descriptor.py
+++ b/tests/test_mace_descriptor.py
@@ -244,7 +244,10 @@ def test_mixed_irrep_selects_only_zero_even_content(
     )
     coord_ext, atype_ext, nlist, mapping = _inputs(descriptor)
     all_features = descriptor._final_product_features(  # noqa: SLF001
-        coord_ext, atype_ext, nlist, mapping,
+        coord_ext,
+        atype_ext,
+        nlist,
+        mapping,
     )
     output = descriptor(coord_ext, atype_ext, nlist, mapping=mapping)[0]
     assert descriptor.output_irreps == "2x0e+2x1o"
@@ -427,7 +430,9 @@ def test_checkpoint_feature_parity_and_serialization_roundtrip(
         type_map=["H", "O"],
     )
     original_state = torch.load(
-        mace_checkpoint, map_location="cpu", weights_only=False,
+        mace_checkpoint,
+        map_location="cpu",
+        weights_only=False,
     ).state_dict()
     for name, value in descriptor.backbone.state_dict().items():
         torch.testing.assert_close(value, original_state[name])

--- a/tests/test_mace_descriptor.py
+++ b/tests/test_mace_descriptor.py
@@ -168,6 +168,21 @@ def test_constructor_registry_and_metadata(mace_checkpoint: Path) -> None:
     assert min_distance is None
 
 
+def test_descriptor_supports_first_import_in_fresh_process() -> None:
+    """Importing the descriptor first must not recurse through the PT entry point."""
+    subprocess.run(
+        [
+            sys.executable,
+            "-c",
+            "from deepmd_gnn.mace_descriptor import MaceDescriptor; "
+            "assert MaceDescriptor.__name__ == 'MaceDescriptor'",
+        ],
+        check=True,
+        capture_output=True,
+        text=True,
+    )
+
+
 def test_constructor_requires_exact_checkpoint_type_map(
     mace_checkpoint: Path,
 ) -> None:

--- a/tests/test_mace_descriptor.py
+++ b/tests/test_mace_descriptor.py
@@ -18,8 +18,13 @@ from deepmd.pt.model.model import get_model
 from deepmd.pt.utils import env
 from deepmd.pt.utils.nlist import extend_input_and_build_neighbor_list
 from e3nn import o3
+from mace.calculators import mace_mp
 from mace.modules import MACE
 
+from deepmd_gnn.mace_checkpoint import (
+    inspect_native_mace_checkpoint,
+    load_native_mace_checkpoint,
+)
 from deepmd_gnn.mace_descriptor import (
     MaceDescriptor,
     _scalar_even_indices,
@@ -33,6 +38,9 @@ def _write_mace_checkpoint(
     *,
     keep_last_layer_irreps: bool,
     pair_repulsion: bool = False,
+    interaction_first: str = "RealAgnosticInteractionBlock",
+    heads: list[str] | None = None,
+    correlation: int | list[int] = 2,
 ) -> Path:
     """Write a tiny native checkpoint with no network access."""
     old_dtype = torch.get_default_dtype()
@@ -43,6 +51,7 @@ def _write_mace_checkpoint(
             num_radial_basis=4,
             num_cutoff_basis=5,
             max_ell=1,
+            interaction_first=interaction_first,
             interaction="RealAgnosticResidualInteractionBlock",
             num_interactions=2,
             num_elements=2,
@@ -51,7 +60,7 @@ def _write_mace_checkpoint(
             avg_num_neighbors=4.0,
             pair_repulsion=pair_repulsion,
             distance_transform="None",
-            correlation=2,
+            correlation=correlation,
             gate="silu",
             MLP_irreps="4x0e",
             std=1.0,
@@ -60,6 +69,7 @@ def _write_mace_checkpoint(
             enable_cueq=False,
             script_model=False,
             keep_last_layer_irreps=keep_last_layer_irreps,
+            heads=heads,
         )
         with torch.no_grad():
             atomic_energies = model.atomic_energies_fn.atomic_energies
@@ -95,6 +105,19 @@ def mixed_mace_checkpoint(tmp_path: Path) -> Path:
     return _write_mace_checkpoint(
         tmp_path / "mixed_mace.model",
         keep_last_layer_irreps=True,
+    )
+
+
+@pytest.fixture
+def mpa_like_checkpoint(tmp_path: Path) -> Path:
+    """Combine the architecture details that distinguish MACE-MPA-0."""
+    return _write_mace_checkpoint(
+        tmp_path / "mpa-like.model",
+        keep_last_layer_irreps=True,
+        pair_repulsion=True,
+        interaction_first="RealAgnosticResidualInteractionBlock",
+        heads=["default"],
+        correlation=[2, 3],
     )
 
 
@@ -196,43 +219,90 @@ def test_constructor_requires_exact_checkpoint_type_map(
         )
 
 
-def test_constructor_accepts_lowercase_single_head(
-    mace_checkpoint: Path,
-    tmp_path: Path,
-) -> None:
-    """A single head named ``default`` is not a multi-head checkpoint."""
-    model = torch.load(mace_checkpoint, map_location="cpu", weights_only=False)
-    model.heads = ["default"]
-    lowercase_checkpoint = tmp_path / "lowercase-head.model"
-    torch.save(model, lowercase_checkpoint)
-
-    descriptor = MaceDescriptor(
-        model_path=lowercase_checkpoint,
-        sel=16,
-        type_map=["H", "O"],
-    )
-    assert descriptor.get_dim_out() == 2
-
-
-def test_constructor_accepts_pair_repulsion_for_descriptor(tmp_path: Path) -> None:
-    """Energy-only pair repulsion does not affect extracted backbone features."""
+def test_constructor_rejects_truly_multi_head_checkpoint(tmp_path: Path) -> None:
+    """Only one named MACE head can define a descriptor backbone."""
     checkpoint = _write_mace_checkpoint(
-        tmp_path / "pair-repulsion.model",
+        tmp_path / "multi-head.model",
         keep_last_layer_irreps=False,
-        pair_repulsion=True,
+        heads=["first", "second"],
     )
+    with pytest.raises(ValueError, match="Multi-head MACE descriptors"):
+        MaceDescriptor(
+            model_path=checkpoint,
+            sel=16,
+            type_map=["H", "O"],
+        )
+
+
+def test_mpa_like_checkpoint_roundtrip_and_gradient(
+    mpa_like_checkpoint: Path,
+) -> None:
+    """MPA-like native checkpoints retain generic backbone architecture."""
     descriptor = MaceDescriptor(
-        model_path=checkpoint,
+        model_path=mpa_like_checkpoint,
         sel=16,
         type_map=["H", "O"],
     )
+    assert descriptor.config["interaction_first"] == (
+        "RealAgnosticResidualInteractionBlock"
+    )
+    assert descriptor.config["interaction"] == ("RealAgnosticResidualInteractionBlock")
+    assert descriptor.config["heads"] == ["default"]
     assert descriptor.config["pair_repulsion"] is True
-    assert descriptor.get_dim_out() == 2
+    assert descriptor.config["correlation"] == [2, 3]
+    assert descriptor.config["keep_last_layer_irreps"] is True
+    state_names = set(descriptor.backbone.state_dict())
+    assert not any("pair_repulsion" in name for name in state_names)
+    assert not any("atomic_energies" in name for name in state_names)
+    assert not any("readout" in name for name in state_names)
+    assert not any("scale_shift" in name for name in state_names)
+
+    output = _descriptor_output(descriptor)
+    output.square().sum().backward()
+    assert output.shape == (1, 3, 2)
+    assert any(
+        parameter.grad is not None and torch.count_nonzero(parameter.grad)
+        for parameter in descriptor.backbone.parameters()
+    )
+
     restored = MaceDescriptor.deserialize(descriptor.serialize())
     torch.testing.assert_close(
         _descriptor_output(restored),
-        _descriptor_output(descriptor),
+        output.detach(),
     )
+
+
+@pytest.mark.slow
+def test_real_medium_mpa0_checkpoint_with_official_helper(tmp_path: Path) -> None:
+    """Exercise official medium-mpa-0 when a local path or network is enabled."""
+    model_source = os.environ.get("MACE_MPA0_PATH")
+    if model_source is None:
+        if os.environ.get("RUN_NETWORK_TESTS") != "1":
+            pytest.skip(
+                "set MACE_MPA0_PATH or RUN_NETWORK_TESTS=1 for medium-mpa-0",
+            )
+        model_source = "medium-mpa-0"
+    native = mace_mp(
+        model=model_source,
+        device=str(env.DEVICE),
+        return_raw_model=True,
+    )
+    model_path = tmp_path / "medium-mpa-0.model"
+    torch.save(native, model_path)
+    native = load_native_mace_checkpoint(model_path, device=env.DEVICE)
+    config = inspect_native_mace_checkpoint(native)
+    descriptor = MaceDescriptor(
+        model_path=model_path,
+        sel=64,
+        type_map=config["type_map"],
+    )
+    assert config["interaction_first"] == "RealAgnosticResidualInteractionBlock"
+    assert config["heads"] == ["default"]
+    assert config["pair_repulsion"] is True
+    output = _descriptor_output(descriptor)
+    output.square().sum().backward()
+    assert torch.isfinite(output).all()
+    assert any(parameter.grad is not None for parameter in descriptor.parameters())
 
 
 def test_forward_shape_and_rotation_invariance(mace_checkpoint: Path) -> None:

--- a/tests/test_mace_descriptor.py
+++ b/tests/test_mace_descriptor.py
@@ -195,6 +195,24 @@ def test_constructor_requires_exact_checkpoint_type_map(
         )
 
 
+def test_constructor_accepts_lowercase_single_head(
+    mace_checkpoint: Path,
+    tmp_path: Path,
+) -> None:
+    """A single head named ``default`` is not a multi-head checkpoint."""
+    model = torch.load(mace_checkpoint, map_location="cpu", weights_only=False)
+    model.heads = ["default"]
+    lowercase_checkpoint = tmp_path / "lowercase-head.model"
+    torch.save(model, lowercase_checkpoint)
+
+    descriptor = MaceDescriptor(
+        model_path=lowercase_checkpoint,
+        sel=16,
+        type_map=["H", "O"],
+    )
+    assert descriptor.get_dim_out() == 2
+
+
 def test_forward_shape_and_rotation_invariance(mace_checkpoint: Path) -> None:
     """Final ``0e`` features have local-atom shape and are invariant."""
     descriptor = MaceDescriptor(

--- a/tests/test_mace_descriptor.py
+++ b/tests/test_mace_descriptor.py
@@ -329,6 +329,49 @@ def test_forward_shape_and_rotation_invariance(mace_checkpoint: Path) -> None:
     torch.testing.assert_close(output, rotated, rtol=2e-6, atol=2e-7)
 
 
+def test_descriptor_forward_is_torchscriptable(mace_checkpoint: Path) -> None:
+    """``dp test`` scripts the eager checkpoint; forward must not use Python builtins."""
+    descriptor = MaceDescriptor(
+        model_path=mace_checkpoint,
+        sel=16,
+        type_map=["H", "O"],
+    )
+    coord_ext, atype_ext, nlist, mapping = _inputs(descriptor)
+    expected = descriptor(coord_ext, atype_ext, nlist, mapping=mapping)[0]
+    scripted = torch.jit.script(descriptor)
+    actual = scripted(coord_ext, atype_ext, nlist, mapping)[0]
+    torch.testing.assert_close(actual, expected)
+
+    model = get_model(
+        {
+            "type": "standard",
+            "type_map": ["H", "O"],
+            "descriptor": {
+                "type": "mace",
+                "model_path": str(mace_checkpoint),
+                "sel": 16,
+            },
+            "fitting_net": {
+                "type": "property",
+                "property_name": "band_gap",
+                "task_dim": 1,
+                "neuron": [8, 8],
+                "precision": "float64",
+            },
+        },
+    )
+    coord = torch.tensor(
+        [[[0.0, 0.0, 0.0], [0.9, 0.1, 0.0], [-0.2, 1.0, 0.3]]],
+        dtype=torch.float64,
+        device=env.DEVICE,
+    ).reshape(1, -1)
+    atype = torch.tensor([[1, 0, 0]], dtype=torch.int64, device=env.DEVICE)
+    expected_pred = model(coord, atype)["band_gap"]
+    scripted_model = torch.jit.script(model)
+    actual_pred = scripted_model(coord, atype)["band_gap"]
+    torch.testing.assert_close(actual_pred, expected_pred)
+
+
 def test_periodic_mapping_and_coordinate_gradient(mace_checkpoint: Path) -> None:
     """Periodic images follow MaceModel mapping without breaking gradients."""
     descriptor = MaceDescriptor(

--- a/tests/test_mace_descriptor.py
+++ b/tests/test_mace_descriptor.py
@@ -343,7 +343,23 @@ def test_periodic_mapping_and_coordinate_gradient(mace_checkpoint: Path) -> None
     )
     box = (torch.eye(3, dtype=torch.float64) * 4.0).reshape(1, 9)
     coord_ext, atype_ext, nlist, mapping = _inputs(descriptor, coord, box)
-    output = descriptor(coord_ext, atype_ext, nlist, mapping=mapping)[0]
+    assert atype_ext.shape[1] > nlist.shape[1]
+    embedded_node_counts = []
+
+    def record_node_count(
+        _module: torch.nn.Module,
+        inputs: tuple[torch.Tensor, ...],
+    ) -> None:
+        embedded_node_counts.append(inputs[0].shape[0])
+
+    handle = descriptor.backbone.node_embedding.register_forward_pre_hook(
+        record_node_count,
+    )
+    try:
+        output = descriptor(coord_ext, atype_ext, nlist, mapping=mapping)[0]
+    finally:
+        handle.remove()
+    assert embedded_node_counts == [nlist.shape[0] * nlist.shape[1]]
     output.square().sum().backward()
     assert coord.grad is not None
     assert torch.count_nonzero(coord.grad)
@@ -362,6 +378,134 @@ def test_periodic_mapping_and_coordinate_gradient(mace_checkpoint: Path) -> None
         mapping=translated_mapping,
     )[0]
     torch.testing.assert_close(output, translated_output, rtol=2e-6, atol=2e-7)
+
+
+def test_final_features_match_native_mace_forward(mace_checkpoint: Path) -> None:
+    """The compact graph adapter preserves MACE's final product features."""
+    native = load_native_mace_checkpoint(mace_checkpoint, device=env.DEVICE)
+    descriptor = MaceDescriptor(
+        model_path=mace_checkpoint,
+        sel=16,
+        type_map=["H", "O"],
+    )
+    coord_ext, atype_ext, nlist, mapping = _inputs(descriptor)
+    del mapping
+    nf, nloc, _ = nlist.shape
+    source_dtype = next(native.parameters()).dtype
+    positions = coord_ext.view(nf * nloc, 3).to(source_dtype)
+    atype = atype_ext[:, :nloc].to(torch.int64)
+    edge_index = torch.ops.deepmd_gnn.edge_index(
+        nlist.to(torch.int64),
+        atype_ext.to(torch.int64),
+        torch.empty(0, dtype=torch.int64, device="cpu"),
+    ).T
+    node_attrs = torch.zeros(
+        (nf * nloc, descriptor.ntypes),
+        dtype=source_dtype,
+        device=env.DEVICE,
+    )
+    node_attrs.scatter_(-1, atype.reshape(-1, 1), 1)
+    native_output = native(
+        {
+            "positions": positions,
+            "node_attrs": node_attrs,
+            "edge_index": edge_index,
+            "shifts": torch.zeros(
+                (edge_index.shape[1], 3),
+                dtype=source_dtype,
+                device=env.DEVICE,
+            ),
+            "cell": torch.zeros(
+                (nf, 3, 3),
+                dtype=source_dtype,
+                device=env.DEVICE,
+            ),
+            "batch": torch.arange(nf, device=env.DEVICE)
+            .unsqueeze(-1)
+            .expand(nf, nloc)
+            .reshape(-1),
+            "ptr": torch.arange(
+                0,
+                (nf + 1) * nloc,
+                nloc,
+                dtype=torch.int64,
+                device=env.DEVICE,
+            ),
+        },
+        compute_force=False,
+    )["node_feats"]
+    assert native_output is not None
+    final_dim = native.products[-1].linear.irreps_out.dim
+    native_final = native_output[:, -final_dim:].view(nf, nloc, final_dim)
+    expected = torch.index_select(
+        native_final,
+        -1,
+        descriptor._scalar_indices.to(env.DEVICE),  # noqa: SLF001
+    ).to(env.GLOBAL_PT_FLOAT_PRECISION)
+    actual = descriptor(coord_ext, atype_ext, nlist)[0]
+    torch.testing.assert_close(actual, expected)
+
+
+def test_compact_periodic_mapping_handles_multiple_frames(
+    mace_checkpoint: Path,
+) -> None:
+    """Compact node indices preserve independent frames with periodic images."""
+    descriptor = MaceDescriptor(
+        model_path=mace_checkpoint,
+        sel=16,
+        type_map=["H", "O"],
+    )
+    coord = torch.tensor(
+        [
+            [[0.1, 0.2, 0.3], [3.8, 0.2, 0.3], [0.2, 3.7, 0.4]],
+            [[0.2, 0.1, 0.4], [3.7, 0.3, 0.2], [0.3, 3.6, 0.5]],
+        ],
+        dtype=torch.float64,
+        device=env.DEVICE,
+    )
+    atype = torch.tensor(
+        [[1, 0, 0], [1, 0, 0]],
+        dtype=torch.int64,
+        device=env.DEVICE,
+    )
+    box = (
+        torch.eye(3, dtype=torch.float64, device=env.DEVICE)
+        .mul(4.0)
+        .reshape(1, 9)
+        .expand(2, 9)
+    )
+    coord_ext, atype_ext, mapping, nlist = extend_input_and_build_neighbor_list(
+        coord.reshape(2, -1),
+        atype,
+        descriptor.get_rcut(),
+        descriptor.get_sel(),
+        mixed_types=True,
+        box=box,
+    )
+    assert atype_ext.shape[1] > nlist.shape[1]
+    batched = descriptor(coord_ext, atype_ext, nlist, mapping=mapping)[0]
+
+    per_frame = []
+    for frame in range(2):
+        frame_coord_ext, frame_atype_ext, frame_mapping, frame_nlist = (
+            extend_input_and_build_neighbor_list(
+                coord[frame : frame + 1].reshape(1, -1),
+                atype[frame : frame + 1],
+                descriptor.get_rcut(),
+                descriptor.get_sel(),
+                mixed_types=True,
+                box=box[frame : frame + 1],
+            )
+        )
+        per_frame.append(
+            descriptor(
+                frame_coord_ext,
+                frame_atype_ext,
+                frame_nlist,
+                mapping=frame_mapping,
+            )[0],
+        )
+    torch.testing.assert_close(batched, torch.cat(per_frame))
 
 
 def test_mixed_irrep_selects_only_zero_even_content(

--- a/tests/test_mace_descriptor.py
+++ b/tests/test_mace_descriptor.py
@@ -177,7 +177,6 @@ def test_constructor_registry_and_metadata(mace_checkpoint: Path) -> None:
     assert descriptor.has_message_passing()
     assert not descriptor.has_message_passing_across_ranks()
     assert all(parameter.requires_grad for parameter in descriptor.parameters())
-    assert descriptor.get_default_chg_spin() is None
     descriptor.set_stat_mean_and_stddev(torch.ones(1), torch.ones(1))
     mean, stddev = descriptor.get_stat_mean_and_stddev()
     assert mean.numel() == 0
@@ -310,6 +309,30 @@ def test_deserialize_keeps_derived_zeroed_buffers(mace_checkpoint: Path) -> None
         _descriptor_output(restored),
         _descriptor_output(descriptor),
     )
+
+
+def test_legacy_checkpoint_supports_strict_scripted_state_restore(
+    mace_checkpoint: Path,
+    tmp_path: Path,
+) -> None:
+    """Derived flags must exist before a training checkpoint is saved."""
+    native = torch.load(mace_checkpoint, map_location="cpu", weights_only=False)
+    for module in native.modules():
+        for name, _ in list(module.named_buffers(recurse=False)):
+            if name.endswith("_zeroed"):
+                delattr(module, name)
+    legacy_path = tmp_path / "legacy.model"
+    torch.save(native, legacy_path)
+    descriptor = MaceDescriptor(
+        model_path=legacy_path,
+        sel=16,
+        type_map=["H", "O"],
+    )
+    restored = MaceDescriptor(sel=16, config=descriptor.config, type_map=["H", "O"])
+    scripted = torch.jit.script(restored)
+    scripted.load_state_dict(descriptor.state_dict())
+    inputs = _inputs(descriptor)
+    torch.testing.assert_close(scripted(*inputs)[0], descriptor(*inputs)[0])
 
 
 def test_mpa_like_checkpoint_roundtrip_and_gradient(
@@ -896,6 +919,24 @@ def test_dp_property_training_smoke(
     prediction, _, _ = tester.wrapper(coord, atype)
     assert torch.isfinite(prediction["band_gap"]).all()
 
+    subprocess.run(
+        [
+            sys.executable,
+            "-m",
+            "deepmd",
+            "--pt",
+            "train",
+            input_path.name,
+            "--init-model",
+            str(saved_checkpoint),
+            "--use-pretrain-script",
+        ],
+        cwd=tmp_path,
+        env=env,
+        check=True,
+        timeout=120,
+    )
+
 
 def test_checkpoint_feature_parity_and_serialization_roundtrip(
     mace_checkpoint: Path,
@@ -959,6 +1000,7 @@ def test_off23_small_checkpoint_features_and_gradients(tmp_path: Path) -> None:
         for parameter in descriptor.backbone.parameters()
     )
     restored = BaseDescriptor.deserialize(descriptor.serialize())
+    torch.jit.script(restored).load_state_dict(descriptor.state_dict())
     torch.testing.assert_close(
         restored(coord_ext, atype_ext, nlist, mapping=mapping)[0],
         output.detach(),

--- a/tests/test_mace_descriptor.py
+++ b/tests/test_mace_descriptor.py
@@ -9,6 +9,7 @@ import os
 import subprocess
 import sys
 from pathlib import Path
+from types import SimpleNamespace
 
 import numpy as np
 import pytest
@@ -24,6 +25,7 @@ from mace.modules import MACE
 from deepmd_gnn.mace_checkpoint import (
     inspect_native_mace_checkpoint,
     load_native_mace_checkpoint,
+    validate_mace_state_dict_load,
 )
 from deepmd_gnn.mace_descriptor import (
     MaceDescriptor,
@@ -41,6 +43,8 @@ def _write_mace_checkpoint(
     interaction_first: str = "RealAgnosticInteractionBlock",
     heads: list[str] | None = None,
     correlation: int | list[int] = 2,
+    num_interactions: int = 2,
+    gate: str = "silu",
 ) -> Path:
     """Write a tiny native checkpoint with no network access."""
     old_dtype = torch.get_default_dtype()
@@ -53,7 +57,7 @@ def _write_mace_checkpoint(
             max_ell=1,
             interaction_first=interaction_first,
             interaction="RealAgnosticResidualInteractionBlock",
-            num_interactions=2,
+            num_interactions=num_interactions,
             num_elements=2,
             hidden_irreps="2x0e + 2x1o",
             atomic_numbers=[1, 8],
@@ -61,7 +65,7 @@ def _write_mace_checkpoint(
             pair_repulsion=pair_repulsion,
             distance_transform="None",
             correlation=correlation,
-            gate="silu",
+            gate=gate,
             MLP_irreps="4x0e",
             std=1.0,
             radial_MLP=[8, 8],
@@ -173,6 +177,7 @@ def test_constructor_registry_and_metadata(mace_checkpoint: Path) -> None:
     assert descriptor.has_message_passing()
     assert not descriptor.has_message_passing_across_ranks()
     assert all(parameter.requires_grad for parameter in descriptor.parameters())
+    assert descriptor.get_default_chg_spin() is None
     descriptor.set_stat_mean_and_stddev(torch.ones(1), torch.ones(1))
     mean, stddev = descriptor.get_stat_mean_and_stddev()
     assert mean.numel() == 0
@@ -188,7 +193,11 @@ def test_constructor_registry_and_metadata(mace_checkpoint: Path) -> None:
         ["H", "O"],
         local_config,
     )
-    assert updated == local_config
+    assert updated["model_path"] == str(mace_checkpoint)
+    assert updated["sel"] == 16
+    assert updated["config"]["type_map"] == ["H", "O"]
+    assert updated["config"]["hidden_irreps"]
+    json.dumps(updated)
     assert min_distance is None
 
 
@@ -232,6 +241,75 @@ def test_constructor_rejects_truly_multi_head_checkpoint(tmp_path: Path) -> None
             sel=16,
             type_map=["H", "O"],
         )
+
+
+def test_feature_backbone_accepts_linear_or_ungated_readouts(tmp_path: Path) -> None:
+    """Energy-head readout metadata is unused and must not block inspection."""
+    linear_path = _write_mace_checkpoint(
+        tmp_path / "linear_readout.model",
+        keep_last_layer_irreps=False,
+        num_interactions=1,
+    )
+    linear_native = load_native_mace_checkpoint(linear_path, device=env.DEVICE)
+    linear_config = inspect_native_mace_checkpoint(linear_native)
+    assert not hasattr(linear_native.readouts[-1], "hidden_irreps")
+    assert linear_config["MLP_irreps"]
+    assert linear_config["gate"]
+    linear_descriptor = MaceDescriptor(
+        model_path=linear_path,
+        sel=16,
+        type_map=["H", "O"],
+    )
+    assert _descriptor_output(linear_descriptor).shape[-1] == 2
+
+    ungated_path = _write_mace_checkpoint(
+        tmp_path / "ungated_readout.model",
+        keep_last_layer_irreps=False,
+        gate="None",
+    )
+    ungated_native = load_native_mace_checkpoint(ungated_path, device=env.DEVICE)
+    ungated_config = inspect_native_mace_checkpoint(ungated_native)
+    assert ungated_config["gate"] == "None"
+    ungated_descriptor = MaceDescriptor(
+        model_path=ungated_path,
+        sel=16,
+        type_map=["H", "O"],
+    )
+    assert _descriptor_output(ungated_descriptor).shape[-1] == 2
+
+
+def test_deserialize_keeps_derived_zeroed_buffers(mace_checkpoint: Path) -> None:
+    """Older native pickles omit reconstructed ``*_zeroed`` buffers."""
+    validate_mace_state_dict_load(
+        SimpleNamespace(
+            missing_keys=["products.0.symmetric_contractions.weights_0_zeroed"],
+            unexpected_keys=[],
+        ),
+    )
+    with pytest.raises(RuntimeError, match=r"node_embedding\.linear\.weight"):
+        validate_mace_state_dict_load(
+            SimpleNamespace(
+                missing_keys=["node_embedding.linear.weight"],
+                unexpected_keys=[],
+            ),
+        )
+
+    descriptor = MaceDescriptor(
+        model_path=mace_checkpoint,
+        sel=16,
+        type_map=["H", "O"],
+    )
+    serialized = descriptor.serialize()
+    serialized["@variables"] = {
+        name: value
+        for name, value in serialized["@variables"].items()
+        if not name.endswith("_zeroed")
+    }
+    restored = BaseDescriptor.deserialize(serialized)
+    torch.testing.assert_close(
+        _descriptor_output(restored),
+        _descriptor_output(descriptor),
+    )
 
 
 def test_mpa_like_checkpoint_roundtrip_and_gradient(
@@ -635,6 +713,55 @@ def test_property_model_composition_and_optimizer_step(
     assert not torch.equal(fitting_before, fitting_parameter)
 
 
+def test_get_model_restores_without_source_checkpoint(
+    mace_checkpoint: Path,
+    tmp_path: Path,
+) -> None:
+    """Saved model definitions reconstruct the backbone without the native pickle."""
+    updated, _ = MaceDescriptor.update_sel(
+        None,
+        ["H", "O"],
+        {
+            "type": "mace",
+            "model_path": str(mace_checkpoint),
+            "sel": 16,
+        },
+    )
+    original = MaceDescriptor(
+        model_path=mace_checkpoint,
+        sel=16,
+        type_map=["H", "O"],
+    )
+    missing = tmp_path / "missing_source.model"
+    restored = get_model(
+        {
+            "type": "standard",
+            "type_map": ["H", "O"],
+            "descriptor": {
+                **updated,
+                "model_path": str(missing),
+            },
+            "fitting_net": {
+                "type": "property",
+                "property_name": "band_gap",
+                "task_dim": 1,
+                "neuron": [8],
+                "precision": "float64",
+            },
+        },
+    )
+    validate_mace_state_dict_load(
+        restored.get_descriptor().backbone.load_state_dict(
+            original.backbone.state_dict(),
+            strict=False,
+        ),
+    )
+    torch.testing.assert_close(
+        _descriptor_output(restored.get_descriptor()),
+        _descriptor_output(original),
+    )
+
+
 def test_dp_property_training_smoke(
     mace_checkpoint: Path,
     tmp_path: Path,
@@ -752,6 +879,23 @@ def test_dp_property_training_smoke(
     assert compared > 0
     assert changed > 0
 
+    extra_params = trained_state["_extra_state"]["model_params"]
+    assert extra_params["descriptor"]["config"]["type_map"] == ["H", "O"]
+    hidden_source = mace_checkpoint.with_name("hidden_source.model")
+    mace_checkpoint.rename(hidden_source)
+    from deepmd.pt.infer.inference import Tester  # noqa: PLC0415
+    from deepmd.pt.utils.env import DEVICE  # noqa: PLC0415
+
+    tester = Tester(str(saved_checkpoint))
+    coord = torch.tensor(
+        [[[0.0, 0.0, 0.0], [0.9, 0.1, 0.0], [-0.2, 1.0, 0.3]]],
+        dtype=torch.float64,
+        device=DEVICE,
+    ).reshape(1, -1)
+    atype = torch.tensor([[1, 0, 0]], dtype=torch.int64, device=DEVICE)
+    prediction, _, _ = tester.wrapper(coord, atype)
+    assert torch.isfinite(prediction["band_gap"]).all()
+
 
 def test_checkpoint_feature_parity_and_serialization_roundtrip(
     mace_checkpoint: Path,
@@ -813,4 +957,9 @@ def test_off23_small_checkpoint_features_and_gradients(tmp_path: Path) -> None:
     assert any(
         parameter.grad is not None and torch.count_nonzero(parameter.grad)
         for parameter in descriptor.backbone.parameters()
+    )
+    restored = BaseDescriptor.deserialize(descriptor.serialize())
+    torch.testing.assert_close(
+        restored(coord_ext, atype_ext, nlist, mapping=mapping)[0],
+        output.detach(),
     )

--- a/tests/test_mace_descriptor.py
+++ b/tests/test_mace_descriptor.py
@@ -1,0 +1,474 @@
+# SPDX-License-Identifier: LGPL-3.0-or-later
+"""Focused tests for the MACE property descriptor."""
+
+from __future__ import annotations
+
+import inspect
+import json
+import os
+import subprocess
+import sys
+from pathlib import Path
+
+import numpy as np
+import pytest
+import torch
+from deepmd.pt.model.descriptor.base_descriptor import BaseDescriptor
+from deepmd.pt.model.model import get_model
+from deepmd.pt.utils.nlist import extend_input_and_build_neighbor_list
+from e3nn import o3
+from mace.modules import MACE
+
+from deepmd_gnn.mace_descriptor import (
+    MaceDescriptor,
+    _scalar_even_indices,
+)
+from deepmd_gnn.mace_network import make_mace_network
+from deepmd_gnn.mace_off import download_mace_off_model
+
+
+def _write_mace_checkpoint(
+    path: Path,
+    *,
+    keep_last_layer_irreps: bool,
+) -> Path:
+    """Write a tiny native checkpoint with no network access."""
+    old_dtype = torch.get_default_dtype()
+    torch.set_default_dtype(torch.float64)
+    try:
+        model = make_mace_network(
+            r_max=3.0,
+            num_radial_basis=4,
+            num_cutoff_basis=5,
+            max_ell=1,
+            interaction="RealAgnosticResidualInteractionBlock",
+            num_interactions=2,
+            num_elements=2,
+            hidden_irreps="2x0e + 2x1o",
+            atomic_numbers=[1, 8],
+            avg_num_neighbors=4.0,
+            pair_repulsion=False,
+            distance_transform="None",
+            correlation=2,
+            gate="silu",
+            MLP_irreps="4x0e",
+            std=1.0,
+            radial_MLP=[8, 8],
+            radial_type="bessel",
+            enable_cueq=False,
+            script_model=False,
+            keep_last_layer_irreps=keep_last_layer_irreps,
+        )
+        with torch.no_grad():
+            atomic_energies = model.atomic_energies_fn.atomic_energies
+            atomic_energies.copy_(
+                torch.linspace(
+                    3.0,
+                    4.0,
+                    atomic_energies.numel(),
+                    dtype=atomic_energies.dtype,
+                    device=atomic_energies.device,
+                ).reshape_as(atomic_energies),
+            )
+    finally:
+        torch.set_default_dtype(old_dtype)
+    torch.save(model, path)
+    return path
+
+
+@pytest.fixture
+def mace_checkpoint(tmp_path: Path) -> Path:
+    """Create a MACE-0.3.5-compatible trusted local checkpoint."""
+    return _write_mace_checkpoint(
+        tmp_path / "small_mace.model",
+        keep_last_layer_irreps=False,
+    )
+
+
+@pytest.fixture
+def mixed_mace_checkpoint(tmp_path: Path) -> Path:
+    """Create a mixed-final-irrep checkpoint when supported by MACE."""
+    if "keep_last_layer_irreps" not in inspect.signature(MACE.__init__).parameters:
+        pytest.skip("installed MACE predates mixed final product irreps")
+    return _write_mace_checkpoint(
+        tmp_path / "mixed_mace.model",
+        keep_last_layer_irreps=True,
+    )
+
+
+def _inputs(
+    descriptor: MaceDescriptor,
+    coord: torch.Tensor | None = None,
+    box: torch.Tensor | None = None,
+) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor, torch.Tensor | None]:
+    if coord is None:
+        coord = torch.tensor(
+            [[[0.0, 0.0, 0.0], [0.9, 0.1, 0.0], [-0.2, 1.0, 0.3]]],
+            dtype=torch.float64,
+        )
+    atype = torch.tensor([[1, 0, 0]], dtype=torch.int64)
+    coord_ext, atype_ext, mapping, nlist = extend_input_and_build_neighbor_list(
+        coord.reshape(1, -1),
+        atype,
+        descriptor.get_rcut(),
+        descriptor.get_sel(),
+        mixed_types=True,
+        box=box,
+    )
+    return coord_ext, atype_ext, nlist, mapping
+
+
+def _descriptor_output(
+    descriptor: MaceDescriptor,
+    coord: torch.Tensor | None = None,
+) -> torch.Tensor:
+    coord_ext, atype_ext, nlist, mapping = _inputs(descriptor, coord)
+    return descriptor(coord_ext, atype_ext, nlist, mapping=mapping)[0]
+
+
+def test_constructor_registry_and_metadata(mace_checkpoint: Path) -> None:
+    """Descriptor registration and metadata follow DeePMD's contract."""
+    descriptor = BaseDescriptor(
+        type="mace",
+        model_path=str(mace_checkpoint),
+        sel=16,
+        type_map=["H", "O"],
+        ntypes=2,
+    )
+    assert isinstance(descriptor, MaceDescriptor)
+    assert descriptor.get_type_map() == ["H", "O"]
+    assert descriptor.get_sel() == [16]
+    assert descriptor.get_nsel() == 16
+    assert descriptor.get_rcut() == pytest.approx(3.0)
+    assert descriptor.get_dim_out() == 2
+    assert descriptor.mixed_types()
+    assert descriptor.has_message_passing()
+    assert not descriptor.has_message_passing_across_ranks()
+    assert all(parameter.requires_grad for parameter in descriptor.parameters())
+    descriptor.set_stat_mean_and_stddev(torch.ones(1), torch.ones(1))
+    mean, stddev = descriptor.get_stat_mean_and_stddev()
+    assert mean.numel() == 0
+    assert stddev.numel() == 0
+
+    local_config = {
+        "type": "mace",
+        "model_path": str(mace_checkpoint),
+        "sel": 16,
+    }
+    updated, min_distance = BaseDescriptor.update_sel(
+        None,
+        ["H", "O"],
+        local_config,
+    )
+    assert updated == local_config
+    assert min_distance is None
+
+
+def test_constructor_requires_exact_checkpoint_type_map(
+    mace_checkpoint: Path,
+) -> None:
+    """Checkpoint element order must equal the model type map."""
+    with pytest.raises(ValueError, match="exactly match checkpoint"):
+        MaceDescriptor(
+            model_path=mace_checkpoint,
+            sel=16,
+            type_map=["O", "H"],
+        )
+
+
+def test_forward_shape_and_rotation_invariance(mace_checkpoint: Path) -> None:
+    """Final ``0e`` features have local-atom shape and are invariant."""
+    descriptor = MaceDescriptor(
+        model_path=mace_checkpoint,
+        sel=16,
+        type_map=["H", "O"],
+    )
+    output = _descriptor_output(descriptor)
+    rotation = torch.tensor(
+        [[0.0, -1.0, 0.0], [1.0, 0.0, 0.0], [0.0, 0.0, 1.0]],
+        dtype=torch.float64,
+    )
+    coord = torch.tensor(
+        [[[0.0, 0.0, 0.0], [0.9, 0.1, 0.0], [-0.2, 1.0, 0.3]]],
+        dtype=torch.float64,
+    )
+    rotated = _descriptor_output(descriptor, coord @ rotation.T)
+    assert output.shape == (1, 3, 2)
+    torch.testing.assert_close(output, rotated, rtol=2e-6, atol=2e-7)
+
+
+def test_periodic_mapping_and_coordinate_gradient(mace_checkpoint: Path) -> None:
+    """Periodic images follow MaceModel mapping without breaking gradients."""
+    descriptor = MaceDescriptor(
+        model_path=mace_checkpoint,
+        sel=16,
+        type_map=["H", "O"],
+    )
+    coord = torch.tensor(
+        [[[0.1, 0.2, 0.3], [3.8, 0.2, 0.3], [0.2, 3.7, 0.4]]],
+        dtype=torch.float64,
+        requires_grad=True,
+    )
+    box = (torch.eye(3, dtype=torch.float64) * 4.0).reshape(1, 9)
+    coord_ext, atype_ext, nlist, mapping = _inputs(descriptor, coord, box)
+    output = descriptor(coord_ext, atype_ext, nlist, mapping=mapping)[0]
+    output.square().sum().backward()
+    assert coord.grad is not None
+    assert torch.count_nonzero(coord.grad)
+
+    translated = coord.detach().clone()
+    translated[:, 1, 0] -= 4.0
+    translated_ext, translated_type, translated_nlist, translated_mapping = _inputs(
+        descriptor,
+        translated,
+        box,
+    )
+    translated_output = descriptor(
+        translated_ext,
+        translated_type,
+        translated_nlist,
+        mapping=translated_mapping,
+    )[0]
+    torch.testing.assert_close(output, translated_output, rtol=2e-6, atol=2e-7)
+
+
+def test_mixed_irrep_selects_only_zero_even_content(
+    mixed_mace_checkpoint: Path,
+) -> None:
+    """Mixed outputs exclude vector and odd scalar channels."""
+    assert _scalar_even_indices(o3.Irreps("2x0e + 1x1o + 1x0o")) == [0, 1]
+    descriptor = MaceDescriptor(
+        model_path=mixed_mace_checkpoint,
+        sel=16,
+        type_map=["H", "O"],
+    )
+    coord_ext, atype_ext, nlist, mapping = _inputs(descriptor)
+    all_features = descriptor._final_product_features(  # noqa: SLF001
+        coord_ext, atype_ext, nlist, mapping,
+    )
+    output = descriptor(coord_ext, atype_ext, nlist, mapping=mapping)[0]
+    assert descriptor.output_irreps == "2x0e+2x1o"
+    torch.testing.assert_close(output, all_features[..., :2])
+
+
+def test_property_model_composition_and_optimizer_step(
+    mace_checkpoint: Path,
+) -> None:
+    """Property fitting updates both backbone and fitting parameters."""
+    model = get_model(
+        {
+            "type": "standard",
+            "type_map": ["H", "O"],
+            "descriptor": {
+                "type": "mace",
+                "model_path": str(mace_checkpoint),
+                "sel": 16,
+            },
+            "fitting_net": {
+                "type": "property",
+                "property_name": "band_gap",
+                "task_dim": 2,
+                "neuron": [8, 8],
+                "precision": "float64",
+            },
+        },
+    )
+    descriptor = model.get_descriptor()
+    fitting = model.get_fitting_net()
+    assert torch.count_nonzero(model.atomic_model.out_bias) == 0
+    backbone_parameter = next(descriptor.backbone.node_embedding.parameters())
+    fitting_parameter = next(fitting.parameters())
+    backbone_before = backbone_parameter.detach().clone()
+    fitting_before = fitting_parameter.detach().clone()
+
+    coord = torch.tensor(
+        [[[0.0, 0.0, 0.0], [0.9, 0.1, 0.0], [-0.2, 1.0, 0.3]]],
+        dtype=torch.float64,
+    ).reshape(1, -1)
+    atype = torch.tensor([[1, 0, 0]], dtype=torch.int64)
+    optimizer = torch.optim.SGD(model.parameters(), lr=1e-3)
+    loss = model(coord, atype)["band_gap"].square().sum()
+    optimizer.zero_grad()
+    loss.backward()
+    assert backbone_parameter.grad is not None
+    assert torch.count_nonzero(backbone_parameter.grad)
+    assert fitting_parameter.grad is not None
+    assert torch.count_nonzero(fitting_parameter.grad)
+    optimizer.step()
+    assert not torch.equal(backbone_before, backbone_parameter)
+    assert not torch.equal(fitting_before, fitting_parameter)
+
+
+def test_dp_property_training_smoke(
+    mace_checkpoint: Path,
+    tmp_path: Path,
+) -> None:
+    """Run one real ``dp --pt train`` property step and save backbone state."""
+    system = tmp_path / "property_data"
+    data_set = system / "set.000"
+    data_set.mkdir(parents=True)
+    (system / "type.raw").write_text("1\n0\n0\n")
+    (system / "type_map.raw").write_text("H\nO\n")
+    coordinates = np.array(
+        [
+            [[0.0, 0.0, 0.0], [0.9, 0.1, 0.0], [-0.2, 1.0, 0.3]],
+            [[0.0, 0.0, 0.0], [0.8, 0.2, 0.1], [-0.1, 0.9, 0.4]],
+            [[0.0, 0.0, 0.0], [1.0, 0.0, 0.2], [-0.3, 1.1, 0.2]],
+            [[0.0, 0.0, 0.0], [0.7, 0.3, 0.0], [-0.2, 0.8, 0.5]],
+        ],
+        dtype=np.float64,
+    )
+    np.save(data_set / "coord.npy", coordinates.reshape(4, -1))
+    np.save(
+        data_set / "box.npy",
+        np.tile((np.eye(3) * 8.0).reshape(1, 9), (4, 1)),
+    )
+    np.save(
+        data_set / "band_gap.npy",
+        np.array([[0.2], [0.7], [-0.4], [1.1]], dtype=np.float64),
+    )
+
+    input_data = {
+        "model": {
+            "type": "standard",
+            "type_map": ["H", "O"],
+            "data_stat_nbatch": 1,
+            "descriptor": {
+                "type": "mace",
+                "model_path": str(mace_checkpoint.resolve()),
+                "sel": 16,
+            },
+            "fitting_net": {
+                "type": "property",
+                "property_name": "band_gap",
+                "task_dim": 1,
+                "neuron": [8],
+                "precision": "float64",
+                "seed": 11,
+            },
+        },
+        "learning_rate": {
+            "type": "exp",
+            "decay_steps": 1,
+            "start_lr": 1e-2,
+            "stop_lr": 1e-3,
+        },
+        "loss": {
+            "type": "property",
+            "loss_func": "mse",
+        },
+        "optimizer": {
+            "type": "Adam",
+        },
+        "training": {
+            "training_data": {
+                "systems": [str(system.resolve())],
+                "batch_size": 2,
+            },
+            "numb_steps": 1,
+            "seed": 17,
+            "disp_freq": 1,
+            "save_freq": 1,
+            "save_ckpt": "model.ckpt",
+        },
+    }
+    input_path = tmp_path / "input.json"
+    input_path.write_text(json.dumps(input_data))
+    env = os.environ.copy()
+    env.setdefault("OMP_NUM_THREADS", "1")
+    subprocess.run(
+        [sys.executable, "-m", "deepmd", "--pt", "train", input_path.name],
+        cwd=tmp_path,
+        env=env,
+        check=True,
+        timeout=120,
+    )
+
+    checkpoint_pointer = tmp_path / "checkpoint"
+    assert checkpoint_pointer.is_file()
+    saved_checkpoint = Path(checkpoint_pointer.read_text().strip())
+    if not saved_checkpoint.is_absolute():
+        saved_checkpoint = tmp_path / saved_checkpoint
+    assert saved_checkpoint.is_file()
+
+    initial_state = torch.load(
+        mace_checkpoint,
+        map_location="cpu",
+        weights_only=False,
+    ).state_dict()
+    trained_state = torch.load(
+        saved_checkpoint,
+        map_location="cpu",
+        weights_only=False,
+    )["model"]
+    compared = 0
+    changed = 0
+    for source_name, initial_value in initial_state.items():
+        if not initial_value.is_floating_point():
+            continue
+        suffix = f"descriptor.backbone.{source_name}"
+        matches = [name for name in trained_state if name.endswith(suffix)]
+        if not matches:
+            continue
+        compared += 1
+        if not torch.equal(initial_value.cpu(), trained_state[matches[0]].cpu()):
+            changed += 1
+    assert compared > 0
+    assert changed > 0
+
+
+def test_checkpoint_feature_parity_and_serialization_roundtrip(
+    mace_checkpoint: Path,
+) -> None:
+    """Checkpoint state and features survive DeePMD serialization."""
+    descriptor = MaceDescriptor(
+        model_path=mace_checkpoint,
+        sel=16,
+        type_map=["H", "O"],
+    )
+    original_state = torch.load(
+        mace_checkpoint, map_location="cpu", weights_only=False,
+    ).state_dict()
+    for name, value in descriptor.backbone.state_dict().items():
+        torch.testing.assert_close(value, original_state[name])
+
+    expected = _descriptor_output(descriptor)
+    serialized = descriptor.serialize()
+    assert serialized["model_path"] is None
+    restored = BaseDescriptor.deserialize(serialized)
+    actual = _descriptor_output(restored)
+    torch.testing.assert_close(actual, expected)
+    for name, value in descriptor.backbone.state_dict().items():
+        torch.testing.assert_close(value, restored.backbone.state_dict()[name])
+
+
+@pytest.mark.slow
+def test_off23_small_checkpoint_features_and_gradients(tmp_path: Path) -> None:
+    """The official MACE-OFF23-small checkpoint is a trainable descriptor."""
+    model_path = download_mace_off_model("off23_small", cache_dir=tmp_path)
+    descriptor = MaceDescriptor(
+        model_path=model_path,
+        sel=64,
+        type_map=["H", "C", "N", "O", "F", "P", "S", "Cl", "Br", "I"],
+    )
+    coord = torch.tensor(
+        [[[0.0, 0.0, 0.0], [0.9572, 0.0, 0.0], [-0.2390, 0.9266, 0.0]]],
+        dtype=torch.float64,
+    )
+    atype = torch.tensor([[3, 0, 0]], dtype=torch.int64)
+    coord_ext, atype_ext, mapping, nlist = extend_input_and_build_neighbor_list(
+        coord.reshape(1, -1),
+        atype,
+        descriptor.get_rcut(),
+        descriptor.get_sel(),
+        mixed_types=True,
+        box=None,
+    )
+    output = descriptor(coord_ext, atype_ext, nlist, mapping=mapping)[0]
+    output.square().mean().backward()
+
+    assert output.shape == (1, 3, 96)
+    assert any(
+        parameter.grad is not None and torch.count_nonzero(parameter.grad)
+        for parameter in descriptor.backbone.parameters()
+    )

--- a/tests/test_mace_descriptor.py
+++ b/tests/test_mace_descriptor.py
@@ -367,7 +367,16 @@ def test_descriptor_forward_is_torchscriptable(mace_checkpoint: Path) -> None:
     ).reshape(1, -1)
     atype = torch.tensor([[1, 0, 0]], dtype=torch.int64, device=env.DEVICE)
     expected_pred = model(coord, atype)["band_gap"]
+    helper_buffers = (
+        "_scalar_indices",
+        "_stat_mean",
+        "_stat_stddev",
+        "_backbone_probe",
+    )
+    eager_state = model.state_dict()
+    assert not any(any(name in key for name in helper_buffers) for key in eager_state)
     scripted_model = torch.jit.script(model)
+    scripted_model.load_state_dict(eager_state)
     actual_pred = scripted_model(coord, atype)["band_gap"]
     torch.testing.assert_close(actual_pred, expected_pred)
 
@@ -483,7 +492,11 @@ def test_final_features_match_native_mace_forward(mace_checkpoint: Path) -> None
     expected = torch.index_select(
         native_final,
         -1,
-        descriptor._scalar_indices.to(env.DEVICE),  # noqa: SLF001
+        torch.tensor(
+            descriptor.scalar_even_indices,
+            dtype=torch.int64,
+            device=env.DEVICE,
+        ),
     ).to(env.GLOBAL_PT_FLOAT_PRECISION)
     actual = descriptor(coord_ext, atype_ext, nlist)[0]
     torch.testing.assert_close(actual, expected)

--- a/tests/test_mace_descriptor.py
+++ b/tests/test_mace_descriptor.py
@@ -32,6 +32,7 @@ def _write_mace_checkpoint(
     path: Path,
     *,
     keep_last_layer_irreps: bool,
+    pair_repulsion: bool = False,
 ) -> Path:
     """Write a tiny native checkpoint with no network access."""
     old_dtype = torch.get_default_dtype()
@@ -48,7 +49,7 @@ def _write_mace_checkpoint(
             hidden_irreps="2x0e + 2x1o",
             atomic_numbers=[1, 8],
             avg_num_neighbors=4.0,
-            pair_repulsion=False,
+            pair_repulsion=pair_repulsion,
             distance_transform="None",
             correlation=2,
             gate="silu",
@@ -211,6 +212,27 @@ def test_constructor_accepts_lowercase_single_head(
         type_map=["H", "O"],
     )
     assert descriptor.get_dim_out() == 2
+
+
+def test_constructor_accepts_pair_repulsion_for_descriptor(tmp_path: Path) -> None:
+    """Energy-only pair repulsion does not affect extracted backbone features."""
+    checkpoint = _write_mace_checkpoint(
+        tmp_path / "pair-repulsion.model",
+        keep_last_layer_irreps=False,
+        pair_repulsion=True,
+    )
+    descriptor = MaceDescriptor(
+        model_path=checkpoint,
+        sel=16,
+        type_map=["H", "O"],
+    )
+    assert descriptor.config["pair_repulsion"] is True
+    assert descriptor.get_dim_out() == 2
+    restored = MaceDescriptor.deserialize(descriptor.serialize())
+    torch.testing.assert_close(
+        _descriptor_output(restored),
+        _descriptor_output(descriptor),
+    )
 
 
 def test_forward_shape_and_rotation_invariance(mace_checkpoint: Path) -> None:

--- a/tests/test_mace_descriptor.py
+++ b/tests/test_mace_descriptor.py
@@ -296,9 +296,12 @@ def test_real_medium_mpa0_checkpoint_with_official_helper(tmp_path: Path) -> Non
         sel=64,
         type_map=config["type_map"],
     )
-    assert config["interaction_first"] == "RealAgnosticResidualInteractionBlock"
-    assert config["heads"] == ["default"]
-    assert config["pair_repulsion"] is True
+    assert config["interaction_first"] == native.interactions[0].__class__.__name__
+    assert config["interaction"] == native.interactions[-1].__class__.__name__
+    assert config["heads"] == list(native.heads)
+    assert config["pair_repulsion"] is bool(
+        getattr(native, "pair_repulsion", False),
+    )
     output = _descriptor_output(descriptor)
     output.square().sum().backward()
     assert torch.isfinite(output).all()

--- a/tests/test_mace_off.py
+++ b/tests/test_mace_off.py
@@ -14,6 +14,7 @@ import torch
 from deepmd.pt.utils.nlist import extend_input_and_build_neighbor_list
 
 from deepmd_gnn.mace import MaceModel
+from deepmd_gnn.mace_network import make_mace_network
 from deepmd_gnn.mace_off import (
     _infer_deepmd_config,
     _load_mace_checkpoint,
@@ -400,6 +401,65 @@ def test_load_mace_off_model_rejects_non_positive_sel() -> None:
     """Sel is a required positive runtime neighbor cap."""
     with pytest.raises(ValueError, match="sel must be positive"):
         load_mace_off_model(model_name=None, model_path=Path("dummy.model"), sel=0)
+
+
+def _make_off_policy_model(
+    *,
+    interaction_first: str = "RealAgnosticInteractionBlock",
+    pair_repulsion: bool = False,
+) -> torch.nn.Module:
+    old_dtype = torch.get_default_dtype()
+    torch.set_default_dtype(torch.float64)
+    try:
+        return make_mace_network(
+            r_max=3.0,
+            num_radial_basis=4,
+            num_cutoff_basis=5,
+            max_ell=1,
+            interaction_first=interaction_first,
+            interaction="RealAgnosticResidualInteractionBlock",
+            num_interactions=2,
+            num_elements=2,
+            hidden_irreps="2x0e",
+            atomic_numbers=[1, 8],
+            avg_num_neighbors=4.0,
+            pair_repulsion=pair_repulsion,
+            distance_transform="None",
+            correlation=2,
+            gate="silu",
+            MLP_irreps="4x0e",
+            std=1.0,
+            radial_MLP=[8, 8],
+            radial_type="bessel",
+            enable_cueq=False,
+            script_model=False,
+        )
+    finally:
+        torch.set_default_dtype(old_dtype)
+
+
+def test_off_policy_rejects_named_lowercase_head() -> None:
+    """Descriptor-compatible head names must not relax OFF conversion."""
+    model = _make_off_policy_model()
+    model.heads = ["default"]
+    with pytest.raises(ValueError, match="Multi-head checkpoints"):
+        _infer_deepmd_config(model)
+
+
+def test_off_policy_rejects_pair_repulsion() -> None:
+    """Descriptor-only pair-repulsion support must remain outside OFF."""
+    model = _make_off_policy_model(pair_repulsion=True)
+    with pytest.raises(ValueError, match="Pair-repulsion checkpoints"):
+        _infer_deepmd_config(model)
+
+
+def test_off_policy_rejects_residual_first_interaction() -> None:
+    """MPA-style residual first blocks must remain outside OFF conversion."""
+    model = _make_off_policy_model(
+        interaction_first="RealAgnosticResidualInteractionBlock",
+    )
+    with pytest.raises(ValueError, match="first interaction block"):
+        _infer_deepmd_config(model)
 
 
 @pytest.mark.slow


### PR DESCRIPTION
## Summary
- add a PyTorch MACE descriptor that loads trusted native `ScaleShiftMACE` checkpoints and exposes final-layer invariant `0e` features
- compose the trainable backbone with DeePMD's standard property fitting pipeline without transferring energy baselines or readouts
- document the workflow and cover serialization, invariance, PBC mapping, end-to-end training, and official MACE-OFF23-small loading

## Test plan
- [x] `python -m ruff check .`
- [x] `.venv-test/bin/python -m pytest tests/test_mace_descriptor.py -q -m \"not slow\"` (8 passed)
- [x] `.venv-test/bin/python -m pytest tests/test_mace_descriptor.py -q -m slow` (1 passed)
- [x] `.venv-test/bin/python -m pytest tests/test_mace_off.py -q -m \"not slow\"` (11 passed)
- [x] `.venv-test/bin/python -m pytest tests/test_model.py -q -k mace` (18 passed)

Made with [Cursor](https://cursor.com)